### PR TITLE
Accessors overriding

### DIFF
--- a/src/core/component/decorators/base.ts
+++ b/src/core/component/decorators/base.ts
@@ -136,6 +136,10 @@ export function paramsFactory<T>(
 				p = params;
 
 			if (desc) {
+				delete meta.props[key];
+				delete meta.fields[key];
+				delete meta.systemFields[key];
+
 				const metaKey = cluster || (
 					'value' in desc ? 'methods' : key in meta.computed && p.cache !== false ? 'computed' : 'accessors'
 				);
@@ -203,6 +207,10 @@ export function paramsFactory<T>(
 
 				return;
 			}
+
+			delete meta.methods[key];
+			delete meta.accessors[key];
+			delete meta.computed[key];
 
 			const
 				metaKey = cluster || (key in meta.props ? 'props' : 'fields'),

--- a/src/core/component/inherit.ts
+++ b/src/core/component/inherit.ts
@@ -171,6 +171,10 @@ export default function inheritMeta(
 					key = keys[i],
 					parent = parentObj[key];
 
+				if (key === 'foo') {
+					console.log(computed[key]);
+				}
+
 				const
 					after = new Set(),
 					watchers = new Map();

--- a/src/p-index/p-index.ts
+++ b/src/p-index/p-index.ts
@@ -10,11 +10,20 @@ import iStaticPage from 'super/i-static-page/i-static-page';
 import { component, field } from 'super/i-block/i-block';
 
 @component({root: true})
-export default class pIndex extends iStaticPage {
+export class iBla extends iStaticPage {
 	@field()
-	foo: number = 0;
+	foo: number;
+}
+
+@component({root: true})
+export default class pIndex extends iBla {
+	get foo(): number {
+		return 1;
+	}
 
 	async mounted(): Promise<void> {
+		console.log(222, this.foo);
+
 		await super.mounted();
 		setTimeout(() => {
 			this.foo++;


### PR DESCRIPTION
```js
@component()
class iBla extends iBlock {
	get foo(): number {
		return 1;
	}
}

@component()
class iFoo extends iBla {
	@field()
	foo: number = 42;

	created(): void {
		console.log(this.foo); // 42
	}
}
```

```js
@component()
class iBla extends iBlock {
	@field()
	foo: number = 1;
}

@component()
class iFoo extends iBla {
	get foo(): number {
		return 42;
	}

	created(): void {
		console.log(this.foo); // 42
	}
}
```