### PR TITLE
Added support for custom emitters within @watch

### DIFF
--- a/src/core/component/decorators/base.ts
+++ b/src/core/component/decorators/base.ts
@@ -26,6 +26,7 @@ export interface WatchHandler<T, A, B> {
 
 export interface FieldWatcherObject<T, A, B> extends WatchOptions {
 	fn: string | WatchHandler<T, A, B>;
+	provideArgs?: boolean;
 }
 
 export type FieldWatcher<T extends VueInterface = VueInterface, A = any, B = A> =

--- a/src/core/component/functional.ts
+++ b/src/core/component/functional.ts
@@ -247,8 +247,6 @@ export function createFakeCtx(
 		}
 	}
 
-	bindWatchers(<any>fakeCtx, 'event');
-
 	{
 		const list = [
 			meta.systemFields,
@@ -298,6 +296,8 @@ export function createFakeCtx(
 					await methods.beforeCreate.fn.call(fakeCtx);
 				}
 			}, stderr);
+
+			bindWatchers(<any>fakeCtx);
 		}
 	}
 
@@ -380,7 +380,8 @@ export function patchVNode(vNode: VNode, ctx: Dictionary, renderCtx: RenderConte
 	}
 
 	ctx.hook = 'created';
-	bindWatchers(<any>ctx, 'field');
+	bindWatchers(<any>ctx);
+
 	runHook('created', meta, ctx).then(async () => {
 		if (methods.created) {
 			await methods.created.fn.call(ctx);

--- a/src/core/component/index.ts
+++ b/src/core/component/index.ts
@@ -90,6 +90,7 @@ export interface ComponentParams {
 
 export interface FieldWatcher extends WatchOptions {
 	fn: WatchHandler<any>;
+	provideArgs?: boolean;
 }
 
 export interface ComponentProp extends PropOptions {
@@ -130,13 +131,19 @@ export interface SystemField<T extends VueInterface = VueInterface> {
 export interface WatchOptionsWithHandler<T extends VueInterface = VueInterface, A = any, B = A> extends WatchOptions {
 	method?: true;
 	event?: boolean;
+	group?: string;
+	provideArgs?: boolean;
 	handler(a: A, b: B): any;
+	handler(...args: A[]): any;
 	handler(ctx: T, a: A, b: B): any;
+	handler(ctx: T, ...args: A[]): any;
 }
 
 export interface MethodWatcher extends WatchOptions {
 	event?: string;
 	field?: string;
+	group?: string;
+	provideArgs?: boolean;
 }
 
 export type Hooks =


### PR DESCRIPTION
```ts
@component()
class bFoo extends iBlock {
	@watch('document:mousemove')
	bla(e) {
		console.log(e);
	}
}
```