### PR TITLE
Fix catch {} in chrome 

### DIFF
--- a/src/super/i-static-page/i-static-page.interface.ss
+++ b/src/super/i-static-page/i-static-page.interface.ss
@@ -129,7 +129,7 @@
 								}
 							});
 
-						} catch {}
+						} catch(_) {}
 
 				- if !@@fatHTML && assetsRequest
 					- block assets


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5569667/46500717-33ebae80-c82c-11e8-9a8a-64a697d2c2c5.png)
![image](https://user-images.githubusercontent.com/5569667/46500761-4534bb00-c82c-11e8-8aa2-486b19e57624.png)
in chrome it's work only from 68 and higher versions

check browser support:
http://kangax.github.io/compat-table/es2016plus/ - Optional catch binding