### PR TITLE
Changed z-index of b-window to 'overall'

### DIFF
--- a/src/base/b-window/b-window.styl
+++ b/src/base/b-window/b-window.styl
@@ -10,11 +10,12 @@
 
 $p = {
 	width: auto
+	zIndexPos: overall
 }
 
 b-window extends i-data
 	absolute top 0 left 0
-	zIndex(overall)
+	zIndex($p.zIndexPos)
 	min-width 100%
 
 	&_width_full &__window

--- a/src/base/b-window/b-window.styl
+++ b/src/base/b-window/b-window.styl
@@ -10,12 +10,11 @@
 
 $p = {
 	width: auto
-	zIndex: 100
 }
 
 b-window extends i-data
 	absolute top 0 left 0
-	z-index $p.zIndex
+	zIndex(overall)
 	min-width 100%
 
 	&_width_full &__window


### PR DESCRIPTION
Set `z-index` of `b-window` the same as `z-index` of `b-dialog`. So now it's higher than `z-index` of `b-cats-list`