### PR TITLE
Fix providers namespace collisions

### DIFF
--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -270,9 +270,8 @@ export default class Provider {
 	/**
 	 * @param [params] - additional parameters
 	 */
-	constructor(params: ProviderParams = {}) {
+	constructor(nm: string, params: ProviderParams = {}) {
 		const
-			nm = this.constructor.name,
 			key = this.cacheId = `${nm}:${JSON.stringify(params)}`,
 			cacheVal = instanceCache[key];
 

--- a/src/core/data/index.ts
+++ b/src/core/data/index.ts
@@ -92,7 +92,8 @@ export function provider(target: Function): void;
 export function provider(nmsOrFn: Function | string): Function | void {
 	if (Object.isString(nmsOrFn)) {
 		return (target) => {
-			providers[`${nmsOrFn}.${target.name}`] = target;
+			const nms = target[$$.namespace] = `${nmsOrFn}.${target.name}`;
+			providers[nms] = target;
 		};
 	}
 
@@ -270,8 +271,9 @@ export default class Provider {
 	/**
 	 * @param [params] - additional parameters
 	 */
-	constructor(nm: string, params: ProviderParams = {}) {
+	constructor(params: ProviderParams = {}) {
 		const
+			nm = this.constructor[$$.namespace],
 			key = this.cacheId = `${nm}:${JSON.stringify(params)}`,
 			cacheVal = instanceCache[key];
 

--- a/src/super/i-data/i-data.ts
+++ b/src/super/i-data/i-data.ts
@@ -565,7 +565,7 @@ export default abstract class iData<T extends object = Dictionary> extends iMess
 				throw new Error(`Provider "${value}" is not defined`);
 			}
 
-			this.dp = new ProviderConstructor(value, this.dataProviderParams);
+			this.dp = new ProviderConstructor(this.dataProviderParams);
 			this.initDataListeners();
 
 		} else {
@@ -606,7 +606,7 @@ export default abstract class iData<T extends object = Dictionary> extends iMess
 				throw new Error(`Provider "${providerNm}" is not defined`);
 			}
 
-			this.dp = new ProviderConstructor(providerNm, value);
+			this.dp = new ProviderConstructor(value);
 			this.initDataListeners();
 		}
 	}

--- a/src/super/i-data/i-data.ts
+++ b/src/super/i-data/i-data.ts
@@ -565,7 +565,7 @@ export default abstract class iData<T extends object = Dictionary> extends iMess
 				throw new Error(`Provider "${value}" is not defined`);
 			}
 
-			this.dp = new ProviderConstructor(this.dataProviderParams);
+			this.dp = new ProviderConstructor(value, this.dataProviderParams);
 			this.initDataListeners();
 
 		} else {
@@ -606,7 +606,7 @@ export default abstract class iData<T extends object = Dictionary> extends iMess
 				throw new Error(`Provider "${providerNm}" is not defined`);
 			}
 
-			this.dp = new ProviderConstructor(value);
+			this.dp = new ProviderConstructor(providerNm, value);
 			this.initDataListeners();
 		}
 	}


### PR DESCRIPTION
Рассказывал давно тебе про эту проблему, в общем как неймспейс для провайдеров использовалось имя класса, что создавало коллизию Campaigns КБ и Campaigns купонов например