### PR TITLE
Fix b image

### DIFF
--- a/src/base/b-image/b-image.styl
+++ b/src/base/b-image/b-image.styl
@@ -39,16 +39,16 @@ b-image extends i-message
 	&__broken
 		display none
 
-	&_disabled_true &__overlay
-	&_progress_true &__overlay
+	&_disabled_true > &__overlay
+	&_progress_true > &__overlay
 		opacity 1
 
 	&__img
 		width 100%
 		background-repeat no-repeat
 
-	&_show-error_true &__broken
+	&_show-error_true > &__broken
 		display block
 
-	&_show-error_true &__img
+	&_show-error_true > &__img
 		display none


### PR DESCRIPTION
Сейчас если в слот `broken` одного `b-image` вставить другой `b-image`, то стили верхнего будут влиять на внутренний:
```
< b-image :src = url1
	< template #broken
		< b-image :src = url2
```