### PR TITLE
Fix/save abt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-beta.183 (2019-09-17)
+
+#### :bug: Bug Fix
+
+* [Fixed `saveABT` didn't save the value received from the adapter if the adapter was an asynchronous function](https://github.com/V4Fire/Client/pull/123)
+
 ## v3.0.0-beta.182 (2019-09-16)
 
 #### :bug: Bug Fix

--- a/src/base/b-slider/b-slider.ts
+++ b/src/base/b-slider/b-slider.ts
@@ -331,6 +331,9 @@ export default class bSlider<T extends object = Dictionary> extends iData<T> {
 				offsetLeft: child.offsetLeft
 			});
 		}
+
+		this.setMod('swipe', true);
+		content.style.setProperty('--offset', `${this.currentOffset}px`);
 	}
 
 	/**

--- a/src/core/abt/engines/index.ts
+++ b/src/core/abt/engines/index.ts
@@ -12,6 +12,6 @@ import { ExperimentsSet } from 'core/abt/interface';
  * Provides a set of abt options
  * @param opts - experiments options
  */
-export default function abtAdapter(opts: unknown): ExperimentsSet {
+export default function abtAdapter(opts: unknown): CanPromise<ExperimentsSet> {
 	return [];
 }

--- a/src/core/abt/index.ts
+++ b/src/core/abt/index.ts
@@ -15,15 +15,11 @@ export const
 
 /**
  * Saves the specified ABT options
- * @param opts
+ * @param options
  */
-export default async function saveABT(opts: unknown): Promise<void> {
+export default async function saveABT(options: unknown): Promise<void> {
 	const
-		config = adapter(opts);
-
-	if (Object.isPromise(config)) {
-		await config.catch(stderr);
-	}
+		config = await adapter(options);
 
 	if (Object.isArray(config)) {
 		if (!Object.fastCompare(state.experiments, config)) {

--- a/src/core/abt/index.ts
+++ b/src/core/abt/index.ts
@@ -8,6 +8,8 @@
 
 import adapter from 'core/abt/engines';
 import state from 'core/component/state';
+
+import { ExperimentsSet } from 'core/abt/interface';
 import { EventEmitter2 as EventEmitter } from 'eventemitter2';
 
 export const
@@ -19,10 +21,10 @@ export const
  */
 export default async function saveABT(opts: unknown): Promise<void> {
 	let
-		config = adapter(opts);
+		config = <CanPromise<ExperimentsSet | void>>adapter(opts);
 
 	if (Object.isPromise(config)) {
-		config = await config.catch(stderr) || [];
+		config = await config.catch(stderr);
 	}
 
 	if (Object.isArray(config)) {

--- a/src/core/abt/index.ts
+++ b/src/core/abt/index.ts
@@ -22,7 +22,7 @@ export default async function saveABT(opts: unknown): Promise<void> {
 		config = adapter(opts);
 
 	if (Object.isPromise(config)) {
-		config = await config;
+		config = await config.catch(stderr) || [];
 	}
 
 	if (Object.isArray(config)) {

--- a/src/core/abt/index.ts
+++ b/src/core/abt/index.ts
@@ -15,11 +15,15 @@ export const
 
 /**
  * Saves the specified ABT options
- * @param options
+ * @param opts
  */
-export default async function saveABT(options: unknown): Promise<void> {
-	const
-		config = await adapter(options);
+export default async function saveABT(opts: unknown): Promise<void> {
+	let
+		config = adapter(opts);
+
+	if (Object.isPromise(config)) {
+		config = await config;
+	}
 
 	if (Object.isArray(config)) {
 		if (!Object.fastCompare(state.experiments, config)) {


### PR DESCRIPTION
Для CHANGELOG

* [Fixed `saveABT`  didn't save the value received from the adapter if the adapter was an asynchronous function](https://github.com/V4Fire/Client/pull/123)