### PR TITLE
Correctly process alias and redirect fields

### DIFF
--- a/src/base/b-router/b-router.ts
+++ b/src/base/b-router/b-router.ts
@@ -326,7 +326,10 @@ export default class bRouter<T extends object = Dictionary> extends iData<T> {
 			if (pageRef in p) {
 				byId = true;
 				obj = p[pageRef];
-				break;
+
+				if (!obj || obj && !obj.redirect && !obj.alias) {
+					break;
+				}
 
 			} else {
 				if (base) {


### PR DESCRIPTION
While b-router setting a page that exists in routes, the component doesn't take in account alias and redirect fields