### PR TITLE
Feat/slots in slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :rocket: New Feature
 
-* Added `beforeComponents` and `afterComponents` slots to `b-slider` component
+* Added `beforeOptions` and `afterOptions` slots to `b-slider` component
 
 ## v3.0.0-beta.229 (2019-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+
+## v3.0.0-beta.230 (2019-12-10)
+
+#### :rocket: New Feature
+
+* Added `beforeComponents` and `afterComponents` slots to `b-slider` component
+
 ## v3.0.0-beta.229 (2019-12-10)
 
 #### :bug: Bug Fix

--- a/src/base/b-slider/b-slider.ss
+++ b/src/base/b-slider/b-slider.ss
@@ -21,18 +21,19 @@
 		: putIn content
 
 			< template v-if = option
+				+= self.slot('beforeComponents')
+
 				< template &
 					v-for = (el, i) in optionsIterator ? optionsIterator(options, self) : options |
 					:key = getOptionKey(el, i)
 				.
-					+= self.slot('beforeComponents')
 
 					< component.&__option &
 						:is = option |
 						:v-attrs = Object.isFunction(optionProps) ? optionProps(el, i, getOptionKey(el, i)) : optionProps
 					.
 
-					+= self.slot('afterComponents')
+				+= self.slot('afterComponents')
 
 			< template v-else
 				+= self.slot()

--- a/src/base/b-slider/b-slider.ss
+++ b/src/base/b-slider/b-slider.ss
@@ -21,7 +21,7 @@
 		: putIn content
 
 			< template v-if = option
-				+= self.slot('beforeComponents')
+				+= self.slot('beforeOptions')
 
 				< template &
 					v-for = (el, i) in optionsIterator ? optionsIterator(options, self) : options |
@@ -33,7 +33,7 @@
 						:v-attrs = Object.isFunction(optionProps) ? optionProps(el, i, getOptionKey(el, i)) : optionProps
 					.
 
-				+= self.slot('afterComponents')
+				+= self.slot('afterOptions')
 
 			< template v-else
 				+= self.slot()

--- a/src/base/b-slider/b-slider.ss
+++ b/src/base/b-slider/b-slider.ss
@@ -25,10 +25,14 @@
 					v-for = (el, i) in optionsIterator ? optionsIterator(options, self) : options |
 					:key = getOptionKey(el, i)
 				.
+					+= self.slot('beforeComponents')
+
 					< component.&__option &
 						:is = option |
 						:v-attrs = Object.isFunction(optionProps) ? optionProps(el, i, getOptionKey(el, i)) : optionProps
 					.
+
+					+= self.slot('afterComponents')
 
 			< template v-else
 				+= self.slot()


### PR DESCRIPTION
Проблема:
Часто бывает что после компонентов в слайдере нужно вставить еще одну карточку (отличную от компонента)

Решение:
2 новых слота до компонентов и после

Конечно всегда есть слот в ремоут провайдере, но не хочется еще в одну обертку врапить, раз компонент сам умеет в загрузку данных