### PR TITLE
Fix i-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-beta.??? (???)
+
+#### :bug: Bug Fix
+
+* Removed `pointer-events` style from `i-access` trait, that causes click propagation behind disabled button
+
 ## v3.0.0-beta.252 (2020-02-13)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* Removed `pointer-events` style from `i-access` trait, that causes click propagation behind disabled button
+* Removed `pointer-events` style from `i-access` trait, that causes click propagation behind a disabled button
 
 ## v3.0.0-beta.252 (2020-02-13)
 

--- a/src/traits/i-access/i-access.styl
+++ b/src/traits/i-access/i-access.styl
@@ -12,10 +12,6 @@ $p = {
 
 i-access
 	if $p.helpers
-		&_disabled_true
-		&_progress_true
-			pointer-events none
-
 		&_disabled_true &__over-wrapper
 		&_progress_true &__over-wrapper
 			display block


### PR DESCRIPTION
Из-за стиля `pointer-events: none` на задизейбленной кнопке не происходит события `onClick` и, соответственно, не вызывается его обработчик, который должен останавливать всплытие события.

В итоге, если задизейбленная кнопка с `position: fixed` находится поверх какого-то другого элемента, с которым может взаимодействовать пользователь, то при нажатии на эту кнопку пользователь на самом деле нажмёт находящийся под кнопкой элемент.