### PR TITLE
Improve SVG sprites

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "string-dasherize": "^1.0.0",
     "stylus": "^0.54.7",
     "stylus-loader": "^3.0.2",
-    "svg-fill-loader": "0.0.8",
     "svg-sprite-loader": "^4.1.6",
     "svg-url-loader": "^3.0.3",
     "svgo": "^1.3.2",

--- a/src/base/b-list/b-list.ts
+++ b/src/base/b-list/b-list.ts
@@ -8,7 +8,6 @@
 
 import symbolGenerator from 'core/symbol';
 
-import iIcon from 'traits/i-icon/i-icon';
 import iVisible from 'traits/i-visible/i-visible';
 import iWidth from 'traits/i-width/i-width';
 
@@ -32,7 +31,7 @@ export const
 	}
 })
 
-export default class bList extends iData implements iIcon, iVisible, iWidth {
+export default class bList extends iData implements iVisible, iWidth {
 	/**
 	 * Initial component value
 	 */
@@ -168,11 +167,6 @@ export default class bList extends iData implements iIcon, iVisible, iWidth {
 
 			return undefined;
 		});
-	}
-
-	/** @see iIcon.getIconLink */
-	getIconLink(iconId: string): string {
-		return iIcon.getIconLink(iconId);
 	}
 
 	/**

--- a/src/form/b-button/b-button.ts
+++ b/src/form/b-button/b-button.ts
@@ -19,7 +19,6 @@ import iVisible from 'traits/i-visible/i-visible';
 import iWidth from 'traits/i-width/i-width';
 import iSize from 'traits/i-size/i-size';
 import iOpenToggle, { CloseHelperEvents } from 'traits/i-open-toggle/i-open-toggle';
-import iIcon from 'traits/i-icon/i-icon';
 
 import iData, {
 
@@ -53,7 +52,7 @@ export type ButtonType<T extends string = any> =
 	}
 })
 
-export default class bButton extends iData implements iAccess, iOpenToggle, iIcon, iVisible, iWidth, iSize {
+export default class bButton extends iData implements iAccess, iOpenToggle, iVisible, iWidth, iSize {
 	/** @override */
 	readonly dataProvider: string = 'Provider';
 
@@ -192,11 +191,6 @@ export default class bButton extends iData implements iAccess, iOpenToggle, iIco
 	/** @see iOpenToggle.toggle */
 	toggle(): Promise<boolean> {
 		return iOpenToggle.toggle(this);
-	}
-
-	/** @see iIcon.getIconLink */
-	getIconLink(iconId: string): string {
-		return iIcon.getIconLink(iconId);
 	}
 
 	/** @see iOpenToggle.onOpenedChange */

--- a/src/form/b-calendar/b-calendar.ts
+++ b/src/form/b-calendar/b-calendar.ts
@@ -11,7 +11,6 @@ import bInputTime from 'form/b-input-time/b-input-time';
 
 import iWidth from 'traits/i-width/i-width';
 import iSize from 'traits/i-size/i-size';
-import iIcon from 'traits/i-icon/i-icon';
 import iOpenToggle, { CloseHelperEvents } from 'traits/i-open-toggle/i-open-toggle';
 
 import iInput, {
@@ -51,7 +50,7 @@ export const
 	$$ = symbolGenerator();
 
 @component()
-export default class bCalendar extends iInput implements iWidth, iSize, iIcon, iOpenToggle {
+export default class bCalendar extends iInput implements iWidth, iSize, iOpenToggle {
 	/** @override */
 	readonly Value!: Value;
 
@@ -374,11 +373,6 @@ export default class bCalendar extends iInput implements iWidth, iSize, iIcon, i
 	/** @see iOpenToggle.toggle */
 	toggle(): Promise<boolean> {
 		return iOpenToggle.toggle(this);
-	}
-
-	/** @see iIcon.getIconLink */
-	getIconLink(iconId: string): string {
-		return iIcon.getIconLink(iconId);
 	}
 
 	/** @see iOpenToggle.onOpenedChange */

--- a/src/form/b-input/b-input.ts
+++ b/src/form/b-input/b-input.ts
@@ -10,7 +10,6 @@ import symbolGenerator from 'core/symbol';
 
 import iWidth from 'traits/i-width/i-width';
 import iSize from 'traits/i-size/i-size';
-import iIcon from 'traits/i-icon/i-icon';
 
 import iInput, {
 
@@ -44,7 +43,7 @@ export const
 	}
 })
 
-export default class bInput extends iInput implements iWidth, iSize, iIcon {
+export default class bInput extends iInput implements iWidth, iSize {
 	/** @override */
 	readonly Value!: Value;
 
@@ -317,11 +316,6 @@ export default class bInput extends iInput implements iWidth, iSize, iIcon {
 	 */
 	@system()
 	private _mask?: {value: Array<string | RegExp>; tpl: string};
-
-	/** @see iIcon.getIconLink */
-	getIconLink(iconId: string): string {
-		return iIcon.getIconLink(iconId);
-	}
 
 	/** @override */
 	async clear(): Promise<boolean> {

--- a/src/global/g-icon/g-icon.interface.styl
+++ b/src/global/g-icon/g-icon.interface.styl
@@ -1,0 +1,14 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+$p = {
+
+}
+
+g-icon
+	fill currentColor

--- a/src/global/g-icon/g-icon.styl
+++ b/src/global/g-icon/g-icon.styl
@@ -1,0 +1,12 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+@import "global/g-icon/g-icon.interface.styl"
+
+.g-icon
+	extends($gIcon)

--- a/src/global/g-icon/index.js
+++ b/src/global/g-icon/index.js
@@ -1,0 +1,9 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+package('g-icon');

--- a/src/icons/b-progress-icon/b-progress-icon.ts
+++ b/src/icons/b-progress-icon/b-progress-icon.ts
@@ -6,14 +6,8 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-import iIcon from 'traits/i-icon/i-icon';
 import iBlock, { component } from 'super/i-block/i-block';
 export * from 'super/i-block/i-block';
 
 @component({functional: true, flyweight: true})
-export default class bProgressIcon extends iBlock implements iIcon {
-	/** @see iIcon.getIconLink */
-	getIconLink(iconId: string): string {
-		return iIcon.getIconLink(iconId);
-	}
-}
+export default class bProgressIcon extends iBlock {}

--- a/src/traits/i-icon/modules/icons.ts
+++ b/src/traits/i-icon/modules/icons.ts
@@ -39,7 +39,7 @@ let
 if (IS_PROD) {
 	// @ts-ignore
 	ctx = (<any>require).context(
-		'!!svg-sprite!svg-fill?fill=currentColor!svgo!@sprite',
+		'!!svg-sprite!svgo!@sprite',
 		true,
 		/\.svg$/
 	);
@@ -47,7 +47,7 @@ if (IS_PROD) {
 } else {
 	// @ts-ignore
 	ctx = (<any>require).context(
-		'!!svg-sprite!svg-fill?fill=currentColor!@sprite',
+		'!!svg-sprite!@sprite',
 		true,
 		/\.svg$/
 	);


### PR DESCRIPTION
- Stop adding attribute `fill="currentColor"` to all elements of SVG sprites
- Remove unused getIconLink methods

With this change any svg can be used as sprite, not only one-colored ones.
What's more, colors of two-colored SVGs can be controlled with CSS or attributes at the root:

```svg
<svg viewBox="0 0 54 54" xmlns="http://www.w3.org/2000/svg" fill="red" color="blue">
    <rect x="2" y="2" width="50" height="50" stroke="currentColor" stroke-width="4"/>
</svg>
```
![example](https://user-images.githubusercontent.com/14364068/77780507-28fe8c80-7065-11ea-8261-9976ae97c779.png)

**WARNING!** This PR leads to breaking change: all `fill` attributes must be removed from SVG sprites.
