### PR TITLE
B virtual scroll on error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-beta.267 ()
+
+#### :bug: Bug Fix
+
+* Used `localError` event on request error instead of `localReady` 
+
 ## v3.0.0-beta.266 (2020-03-30)
 
 #### :bug: Bug Fix

--- a/src/base/b-virtual-scroll/b-virtual-scroll.ts
+++ b/src/base/b-virtual-scroll/b-virtual-scroll.ts
@@ -217,7 +217,10 @@ export default class bVirtualScroll extends iData implements iItems {
 		this.scrollRender.reInit();
 	}
 
-	/** @override */
+	/**
+	 * @override
+	 * @emits localEvent:localReady
+	 */
 	protected initRemoteData(): CanUndef<unknown[]> {
 		if (!this.db) {
 			return;
@@ -252,7 +255,10 @@ export default class bVirtualScroll extends iData implements iItems {
 		return this.reInit();
 	}
 
-	/** @override */
+	/**
+	 *  @override
+	 *  @emits localEvent:localError
+	 */
 	protected onRequestError(err: Error | RequestError<unknown>, retry: RetryRequestFn): void {
 		super.onRequestError(err, retry);
 

--- a/src/base/b-virtual-scroll/b-virtual-scroll.ts
+++ b/src/base/b-virtual-scroll/b-virtual-scroll.ts
@@ -256,7 +256,6 @@ export default class bVirtualScroll extends iData implements iItems {
 	protected onRequestError(err: Error | RequestError<unknown>, retry: RetryRequestFn): void {
 		super.onRequestError(err, retry);
 
-		this.localEvent.emit('localReady');
-		this.scrollRender.setRefVisibility('retry', true);
+		this.localEvent.emit('localError');
 	}
 }

--- a/src/base/b-virtual-scroll/modules/scroll-render.ts
+++ b/src/base/b-virtual-scroll/modules/scroll-render.ts
@@ -348,6 +348,7 @@ export default class ScrollRender {
 	 * Handler: error occurred
 	 */
 	protected onError(): void {
+		this.setLoadersVisibility(false);
 		this.setRefVisibility('retry', true);
 	}
 }

--- a/src/base/b-virtual-scroll/modules/scroll-render.ts
+++ b/src/base/b-virtual-scroll/modules/scroll-render.ts
@@ -125,7 +125,7 @@ export default class ScrollRender {
 
 		this.component.meta.hooks.mounted.push({fn: () => {
 			this.setLoadersVisibility(true);
-			this.async.once(this.component.localEvent, 'localReady', this.onReady.bind(this), {label: $$.reInit});
+			this.initEventHandlers();
 		}});
 	}
 
@@ -146,7 +146,7 @@ export default class ScrollRender {
 		this.setRefVisibility('done', false);
 		this.setRefVisibility('empty', false);
 
-		this.async.once(this.component.localEvent, 'localReady', this.onReady.bind(this), {label: $$.reInit});
+		this.initEventHandlers();
 	}
 
 	/**
@@ -223,6 +223,14 @@ export default class ScrollRender {
 	setLoadersVisibility(show: boolean): void {
 		this.setRefVisibility('tombstones', show);
 		this.setRefVisibility('loader', show);
+	}
+
+	/**
+	 * Event handlers initialisation
+	 */
+	protected initEventHandlers(): void {
+		this.async.once(this.component.localEvent, 'localReady', this.onReady.bind(this), {label: $$.reInit});
+		this.async.once(this.component.localEvent, 'localError', this.onError.bind(this), {label: $$.reInit});
 	}
 
 	/**
@@ -334,5 +342,12 @@ export default class ScrollRender {
 	protected onRequestsDone(): void {
 		this.setLoadersVisibility(false);
 		this.setRefVisibility('done', true);
+	}
+
+	/**
+	 * Handler: error occurred
+	 */
+	protected onError(): void {
+		this.setRefVisibility('retry', true);
 	}
 }

--- a/src/base/b-virtual-scroll/modules/scroll-render.ts
+++ b/src/base/b-virtual-scroll/modules/scroll-render.ts
@@ -229,8 +229,8 @@ export default class ScrollRender {
 	 * Event handlers initialisation
 	 */
 	protected initEventHandlers(): void {
-		this.async.once(this.component.localEvent, 'localReady', this.onReady.bind(this), {label: $$.reInit});
-		this.async.once(this.component.localEvent, 'localError', this.onError.bind(this), {label: $$.reInit});
+		this.component.localEvent.once('localReady', this.onReady.bind(this), {label: $$.reInit});
+		this.component.localEvent.once('localError', this.onError.bind(this), {label: $$.reInit});
 	}
 
 	/**


### PR DESCRIPTION
**Проблема**
При частом изменении пропа `request` и медленном интернете отображаются неверные данные.

**Причина**
* При изменении пропа `request` вызывается `reInit` в `scroll-render`'е, который вешает обработчик на событие `localReady`, выполняющийся один раз.
* После этого абортится предыдущий запрос `b-virtual-scroll`'а, который обрабатывается в методе `onRequestError`, эмитящем событие `localReady` и делается новый запрос.
* Это событие перехватывает `scroll-render` и выполняет метод `onReady`, отрисовывая старые данные (`options`) последнего успешного запроса `b-virtual-scroll`'а.
* Когда приходит ответ на новый запрос, он никем не обрабатывается, т.к. обработчик внутри `scroll-render`'а уже один раз выполнился.

**Решение**
Разделение событий на успешное получение и обработку данных и на ошибку запроса внутри `b-virtual-scroll`'а
