### PR TITLE
Fix rendering next chunk in b-virtual-scroll

### DIFF
--- a/src/base/b-virtual-scroll/modules/scroll-render.ts
+++ b/src/base/b-virtual-scroll/modules/scroll-render.ts
@@ -310,7 +310,7 @@ export default class ScrollRender {
 		const
 			{component, items} = this,
 			{chunkSize, renderGap} = component,
-			currentRender = this.chunk * chunkSize;
+			currentRender = (this.chunk - 1) * chunkSize;
 
 		if (index + renderGap + chunkSize >= items.length) {
 			this.scrollRequest.try();


### PR DESCRIPTION
The field `ScrollRender.chunk` in functions `ScrollRender.onReady` and `ScrollRender.render` is used as _next chunk that will be rendering when is needed_. But the function `ScrollRender.onNodeIntersect` use it as _"last rendered chunk"_. Provided PR fix this inconsistency.