### PR TITLE
Fix/scroll unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-beta.270 (2020-04-21)
+
+#### :bug: Bug Fix
+
+* Fixed repetitive iLockPageScroll.unlock calls `traits/iLockPageScroll/lock`
+
 ## v3.0.0-beta.269 (2020-04-15)
 
 #### :rocket: New Feature

--- a/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
+++ b/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
@@ -160,7 +160,7 @@ export default abstract class iLockPageScroll {
 				body.style.paddingRight = component[$$.paddingRight] || '';
 				res();
 
-			}, {group, label: $$.unlock});
+			}, {group, label: $$.unlockRaf, join: true});
 
 		}), {
 			group,

--- a/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
+++ b/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
@@ -25,7 +25,7 @@ export default abstract class iLockPageScroll {
 	 */
 	static lock<T extends iBlock>(component: T, scrollableNode?: Element): Promise<void> {
 		const
-			{$root: r, $root: {async: $a}} = component;
+			{$root: r, $root: {unsafe: {async: $a}}} = component;
 
 		let
 			promise = Promise.resolve();
@@ -104,7 +104,7 @@ export default abstract class iLockPageScroll {
 
 					component[$$.scrollTop] = scrollTop;
 					body.style.top = `-${scrollTop}px`;
-					r.setRootMod('lockScrollMobile', true, r);
+					r.setRootMod('lockScrollMobile', true);
 
 					res();
 
@@ -120,7 +120,7 @@ export default abstract class iLockPageScroll {
 
 					component[$$.paddingRight] = body.style.paddingRight;
 					body.style.paddingRight = `${scrollBarWidth}px`;
-					r.setRootMod('lockScrollDesktop', true, r);
+					r.setRootMod('lockScrollDesktop', true);
 
 					res();
 
@@ -138,7 +138,7 @@ export default abstract class iLockPageScroll {
 	 */
 	static unlock<T extends iBlock>(component: T): Promise<void> {
 		const
-			{$root: r, $root: {async: $a}} = component.unsafe,
+			{$root: r, $root: {unsafe: {async: $a}}} = component.unsafe,
 			{body} = document;
 
 		if (!r[$$.isLocked]) {
@@ -149,8 +149,8 @@ export default abstract class iLockPageScroll {
 			$a.off({group});
 
 			$a.requestAnimationFrame(() => {
-				r.removeRootMod('lockScrollMobile', true, r);
-				r.removeRootMod('lockScrollDesktop', true, r);
+				r.removeRootMod('lockScrollMobile', true);
+				r.removeRootMod('lockScrollDesktop', true);
 				r[$$.isLocked] = false;
 
 				if (is.Android) {


### PR DESCRIPTION
При быстром повторном вызове `iLockPageScroll.unlock` оба созданных потока повисают и не возвращаются. Такое происходит потому, что при `join: true` для возвращаемого промиса сохранялся только первый поток, при этом внутренний вызов `requestAnimationFrame` уничтожался в нем, так как `raf` с таким же лейблом вызывается во втором потоке, а стратегия `join: true` для него не задана. Это приводит к тому, что, например, код
```(javaScript)
iLockPageScroll.unlock().then(() => {console.log(1)});
iLockPageScroll.unlock().then(() => {console.log(2)});
```
ничего не печатает.

Данный PR чинит это поведение путем добавления стратегии `join: true` и своего лейбла для `raf`. Также исправлены конфликты типов в `iLockPageScroll`.