### PR TITLE
Fix/scrollto call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-rc.11 (2020-05-10)
+
+#### :bug: Bug Fix
+
+* Fixed calling `window.scrollTo` without window context
+
 ## v3.0.0-rc.10 (2020-05-10)
 
 #### :rocket: New Feature

--- a/src/super/i-page/i-page.ts
+++ b/src/super/i-page/i-page.ts
@@ -103,10 +103,10 @@ export default abstract class iPage extends iData implements iVisible {
 
 		const scroll = (opts: ScrollToOptions) => {
 			try {
-				scrollTo(opts);
+				window.scrollTo(opts);
 
 			} catch {
-				scrollTo(opts.left == null ? pageXOffset : opts.left, opts.top == null ? pageYOffset : opts.top);
+				window.scrollTo(opts.left == null ? pageXOffset : opts.left, opts.top == null ? pageYOffset : opts.top);
 			}
 		};
 


### PR DESCRIPTION
При вызове `scrollTo` без контекста может падать ошибка при использовании полифилла (например, [scroll-behavior-polyfill](https://github.com/wessberg/scroll-behavior-polyfill)), который полагается на наличие контекста `window` при патчинге.