### PR TITLE
Удаление padding-bottom

### DIFF
--- a/src/base/b-bottom-slide/CHANGELOG.md
+++ b/src/base/b-bottom-slide/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## (2020-05-20)
+
+#### :bug: Bug Fix
+
+* Removed padding-bottom of the page element
+
 ## (2020-04-28)
 
 #### :bug: Bug Fix

--- a/src/base/b-bottom-slide/b-bottom-slide.ts
+++ b/src/base/b-bottom-slide/b-bottom-slide.ts
@@ -567,8 +567,7 @@ export default class bBottomSlide extends iBlock implements iLockPageScroll, iOp
 
 		if (currentPage) {
 			Object.assign((<HTMLElement>currentPage.el).style, {
-				maxHeight: maxVisiblePx.px,
-				paddingBottom: header.clientHeight.px
+				maxHeight: maxVisiblePx.px
 			});
 		}
 


### PR DESCRIPTION
В `b-bottom-slide` в методе `initGeometry` нужно удалить проставление `paddingBottom`, т.к. высота `currentPage` на этот момент уже высчитана и проставляется всему контенту шторки через `content.style.height`. Добавление же паддинга приводит к уменьшению доступной высоты для контента и появлению полосы прокрутки

Правильнее выставлять паддинг через стили
