### PR TITLE
Page title cache fix

### DIFF
--- a/src/super/i-page/CHANGELOG.md
+++ b/src/super/i-page/CHANGELOG.md
@@ -1,0 +1,16 @@
+Changelog
+=========
+
+> **Tags:**
+> - :boom:       [Breaking Change]
+> - :rocket:     [New Feature]
+> - :bug:        [Bug Fix]
+> - :memo:       [Documentation]
+> - :house:      [Internal]
+> - :nail_care:  [Polish]
+
+## (2020-05-21)
+
+#### :bug: Bug Fix
+
+* Fixed `pageTitle` caching

--- a/src/super/i-page/i-page.ts
+++ b/src/super/i-page/i-page.ts
@@ -14,7 +14,7 @@
 import symbolGenerator from 'core/symbol';
 import iVisible from 'traits/i-visible/i-visible';
 
-import iData, { component, prop, system, watch, hook, ModsDecl } from 'super/i-data/i-data';
+import iData, { component, prop, system, watch, computed, hook, ModsDecl } from 'super/i-data/i-data';
 import { TitleValue, StageTitles, ScrollOptions } from 'super/i-page/interface';
 
 export * from 'super/i-data/i-data';
@@ -49,6 +49,7 @@ export default abstract class iPage extends iData implements iVisible {
 	/**
 	 * Page title
 	 */
+	@computed({cache: false})
 	get pageTitle(): string {
 		return this.r.pageTitle;
 	}


### PR DESCRIPTION
Геттер `pageTitle` в `iPage` просто проксирует получение заголовка из рута. Т.к. все геттеры теперь кэшируют ответ, то он запоминает первый ответ, всегда отдаёт его и не знает когда можно инвалидировать  свой кэш. Поэтому просто вырубаю для него кэш