### PR TITLE
[Build] Fix webp images generating and loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-rc.32 (2020-06-17)
+
+#### :bug: Bug Fix
+
+* Fixed a problem with converting images to webp `static:image:webp` at `build/static.gulp.js`
+* Fixed a problem with image loading with `image-webpack-plugin` at `build/module.webpack.js`
+
 ## v3.0.0-rc.31 (2020-06-17)
 
 #### :bug: Bug Fix

--- a/build/module.webpack.js
+++ b/build/module.webpack.js
@@ -238,7 +238,22 @@ module.exports = async function ({buildId, plugins}) {
 	});
 
 	loaders.rules.set('img', {
-		test: /\.(?:png|webp|gif|jpe?g)$/,
+		test: /\.(?:png|gif|jpe?g)$/,
+		use: [
+			{
+				loader: 'url',
+				options: fileLoaderOpts
+			}
+		].concat(
+			isProd ? {
+				loader: 'image-webpack',
+				options: Object.reject(imageOpts, ['webp'])
+			} : []
+		)
+	});
+
+	loaders.rules.set('img.webp', {
+		test: /\.webp$/,
 		use: [
 			{
 				loader: 'url',

--- a/build/static.gulp.js
+++ b/build/static.gulp.js
@@ -135,11 +135,11 @@ module.exports = function (gulp = require('gulp')) {
 
 			return gulp.src([path.join(isArr ? src[0] : src, '/**/*.@(png|jpg|jpeg)')].concat(isArr ? src[1] || [] : []))
 				.pipe($.plumber())
-				.pipe($.extReplace('webp'))
 
 				.pipe($.imagemin([
 					$.imagemin.webp({quality: 100, lossless: true})
 				]))
+				.pipe($.extReplace('webp'))
 				.pipe(gulp.dest(isArr ? src[0] : src));
 		}
 


### PR DESCRIPTION
- Исправление генерации webp-изображений
- Исправление подключения webp-изображений в проект

`image-webpack-loader` не умеет создавать _копии_ webp-изображений. При этом он конвертирует существующие png/jpeg в webp, не изменяя при этом их расширений.
Некоторые issues:
- https://github.com/tcoopman/image-webpack-loader/issues/179#issuecomment-460757281
- https://github.com/tcoopman/image-webpack-loader/issues/138#issuecomment-497456326