### PR TITLE
[bBottomSlide] Исправление отображения высокого контента

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changelog
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
 
+## v3.0.0-rc.35 (2020-06-30)
+
+#### :bug: Bug Fix
+
+* Fixed incorrect bottom-slide positioning with content bigger than `maxVisiblePx`
+
 ## v3.0.0-rc.34 (2020-06-30)
 
 #### :house: Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
 
-## v3.0.0-rc.35 (2020-06-30)
+## v3.0.0-rc.35 (2020-07-02)
 
 #### :bug: Bug Fix
 

--- a/src/base/b-bottom-slide/CHANGELOG.md
+++ b/src/base/b-bottom-slide/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v3.0.0-rc.35 (2020-06-30)
+## v3.0.0-rc.35 (2020-07-02)
 
 #### :bug: Bug Fix
 

--- a/src/base/b-bottom-slide/CHANGELOG.md
+++ b/src/base/b-bottom-slide/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.0.0-rc.35 (2020-06-30)
+
+#### :bug: Bug Fix
+
+* Fixed incorrect bottom-slide positioning with content bigger than `maxVisiblePx`
+
 ## v3.0.0-rc.16 (2020-05-21)
 
 #### :bug: Bug Fix

--- a/src/base/b-bottom-slide/b-bottom-slide.ts
+++ b/src/base/b-bottom-slide/b-bottom-slide.ts
@@ -542,7 +542,7 @@ export default class bBottomSlide extends iBlock implements iLockPageScroll, iOp
 	@wait('ready')
 	protected initGeometry(): CanPromise<void> {
 		const
-			{maxVisiblePercent, $refs: {header, content, view}} = this;
+			{maxVisiblePercent, $refs: {header, content, view, window}} = this;
 
 		const
 			currentPage = this.history?.current?.content;
@@ -567,11 +567,11 @@ export default class bBottomSlide extends iBlock implements iLockPageScroll, iOp
 
 		if (currentPage) {
 			Object.assign((<HTMLElement>currentPage.el).style, {
-				maxHeight: maxVisiblePx.px
+				maxHeight: (maxVisiblePx === 0 ? 0 : (maxVisiblePx - header.clientHeight)).px
 			});
 		}
 
-		Object.assign(view.style, {
+		Object.assign(window.style, {
 			// If documentElement height is equal to zero, maxVisiblePx is always be zero too,
 			// even after new calling of initGeometry.
 			// Also, view.clientHeight above would return zero as well, even though the real size is bigger.


### PR DESCRIPTION
- Для элемента страницы выставлять `maxHeight` без учета шапки шторки. Раньше максимальная высота для страницы включала в себя высоту шапки, хотя на самом деле шапка находится вне страницы;
- Общую высоту контента (включая шапку) проставлять для элемента `window`, т.к. он содержит в себе уже и шапку, и страницу.
