### PR TITLE
Fix directives in functional and composite components

### DIFF
--- a/src/core/component/engines/vue/vnode.ts
+++ b/src/core/component/engines/vue/vnode.ts
@@ -53,7 +53,7 @@ export function patchVNode(vnode: VNode, ctx: ComponentInterface, renderCtx: Ren
 			vData.attrs = Object.assign(vData.attrs ?? {}, data.attrs);
 		}
 
-		vData.directives = data.directives;
+		vData.directives = Array.concat([], vData.directives, data.directives);
 		vData.on = vData.on ?? {};
 
 		if (data.nativeOn) {

--- a/src/core/component/flyweight/index.ts
+++ b/src/core/component/flyweight/index.ts
@@ -234,7 +234,7 @@ export function parseVNodeAsFlyweight(
 
 	newVData.staticClass = Array.concat([], newVData.staticClass, componentData.staticClass).join(' ');
 	newVData.class = Array.concat([], newVData.class, componentData.class);
-	newVData.directives = componentData.directives;
+	newVData.directives = Array.concat([], newVData.directives, componentData.directives);
 
 	return newVNode;
 }


### PR DESCRIPTION

Directive `v-image` **and any other directive** cannot be applied at root node in functional and composite components. Directive can be added to root node this way:
```
- namespace [%fileName%]

- include 'super/i-block'|b as placeholder

- template index() extends ['i-block'].index
	- rootWrapper = true

	- block rootAttrs
		? Object.assign(rootAttrs, {'v-image': '{src: imageUrl}'})
```
But it doesn't work due to the bug caused by mistake in patching virtual nodes. The PR fixes this misbehaviour.