### PR TITLE
v-image fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
-## v3.0.0-rc89 (2020-10-20)
+## v3.0.0-rc.89 (2020-10-20)
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-rc89 (2020-10-20)
+
+#### :bug: Bug Fix
+
+* Fixed the background image cleaning `core/dom/image/loader.ts`
+
 ## v3.0.0-rc.88 (2020-10-13)
 
 #### :rocket: New Feature

--- a/src/core/dom/image/CHANGELOG.md
+++ b/src/core/dom/image/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v3.0.0-rc89 (2020-10-20)
+## v3.0.0-rc.89 (2020-10-20)
 
 #### :bug: Bug Fix
 

--- a/src/core/dom/image/CHANGELOG.md
+++ b/src/core/dom/image/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.0.0-rc89 (2020-10-20)
+
+#### :bug: Bug Fix
+
+* Fixed the background image cleaning
+
 ## v3.0.0-rc.75 (2020-10-07)
 
 #### :rocket: New Feature

--- a/src/core/dom/image/loader.ts
+++ b/src/core/dom/image/loader.ts
@@ -180,7 +180,7 @@ export default class ImageLoader {
 	 * @param imageSrc
 	 */
 	setBackgroundImage(el: HTMLElement, imageSrc: string): void {
-		el.style.backgroundImage = `url('${imageSrc}')`;
+		el.style.backgroundImage = imageSrc === '' ? '' : `url('${imageSrc}')`;
 	}
 
 	/**


### PR DESCRIPTION
`v-image` directive unbinding leads to clearing an element's state. So it calls method `setBackgroundImage` of `ImageLoader` and passes empty string as an `imageSrc` param. In this case the element's `backgroundImage` becomes url of empty string, i.e. `url('')`.

The PR fixes this behaviour.