### PR TITLE
Fix/v image styles clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.0.0-rc.139 (2021-02-05)
+
+#### :bug: Bug Fix
+
+* Fixed cleaning of background styles `core/dom/image`
+
 ## v3.0.0-rc.138 (2021-02-04)
 
 #### :rocket: New Feature

--- a/src/core/dom/image/CHANGELOG.md
+++ b/src/core/dom/image/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.0.0-rc.139 (2021-02-05)
+
+#### :bug: Bug Fix
+
+* Fixed cleaning of background styles
+
 ## v3.0.0-rc.89 (2020-10-20)
 
 #### :bug: Bug Fix

--- a/src/core/dom/image/loader.ts
+++ b/src/core/dom/image/loader.ts
@@ -174,16 +174,6 @@ export default class ImageLoader {
 	}
 
 	/**
-	 * Sets background CSS properties to the specified element
-	 *
-	 * @param el
-	 * @param imageSrc
-	 */
-	setBackgroundImage(el: HTMLElement, imageSrc: string): void {
-		el.style.backgroundImage = imageSrc === '' ? '' : `url('${imageSrc}')`;
-	}
-
-	/**
 	 * Returns true if the specified element is an instance of `HTMLImageElement`
 	 * @param el
 	 */
@@ -200,7 +190,7 @@ export default class ImageLoader {
 			el.src = '';
 
 		} else {
-			this.setBackgroundImage(el, '');
+			this.clearBackgroundStyles(el);
 		}
 
 		this.clearShadowState(el);
@@ -375,6 +365,20 @@ export default class ImageLoader {
 			backgroundPosition,
 			backgroundRepeat,
 			paddingBottom
+		});
+	}
+
+	/**
+	 * Clears background CSS styles of the specified element
+	 * @param el
+	 */
+	protected clearBackgroundStyles(el: HTMLElement): void {
+		Object.assign(el.style, {
+			backgroundImage: '',
+			backgroundSize: '',
+			backgroundPosition: '',
+			backgroundRepeat: '',
+			paddingBottom: ''
 		});
 	}
 

--- a/src/core/dom/image/test/index.js
+++ b/src/core/dom/image/test/index.js
@@ -1034,5 +1034,40 @@ module.exports = async (page, params) => {
 			await h.bom.waitForIdleCallback(page);
 			expect(await divNode.evaluate((ctx) => parseInt(ctx.style.paddingBottom, 10))).toBe(52);
 		});
+
+		it('div tag clearing all styles after unbinding', async () => {
+			const
+				tag = 'div',
+				beforeImg = 'linear-gradient(rgb(230, 100, 101), rgb(145, 152, 229))',
+				afterImg = 'linear-gradient(rgb(230, 97, 101), rgb(145, 40, 229))';
+
+			await imageLoader.evaluate((imageLoaderCtx, [tag, mainSrc, beforeImg, afterImg]) => {
+				const
+					target = document.getElementById(`${tag}-target`);
+
+				imageLoaderCtx.init(target, {
+					src: mainSrc,
+					bgOptions: {size: 'contain', ratio: 100 / 50, beforeImg, afterImg, position: '47% 47%', repeat: 'no-repeat'},
+					ctx: globalThis.dummy
+				});
+			}, [tag, images.pngImage, beforeImg, afterImg]);
+
+			await h.bom.waitForIdleCallback(page);
+
+			await imageLoader.evaluate((imageLoaderCtx, tag) => {
+				const
+					target = document.getElementById(`${tag}-target`);
+
+				imageLoaderCtx.clearElement(target);
+			}, tag);
+
+			await h.bom.waitForIdleCallback(page);
+
+			expect(await getNode(tag).evaluate((ctx) => ctx.style.backgroundImage)).toBe('');
+			expect(await getNode(tag).evaluate((ctx) => ctx.style.backgroundSize)).toBe('');
+			expect(await getNode(tag).evaluate((ctx) => ctx.style.backgroundPosition)).toBe('');
+			expect(await getNode(tag).evaluate((ctx) => ctx.style.backgroundRepeat)).toBe('');
+			expect(await getNode(tag).evaluate((ctx) => ctx.style.paddingBottom)).toBe('');
+		});
 	});
 };


### PR DESCRIPTION
При удалении директивы `v-image` удалялись не все стили, которые она выставляла для фона. 