### PR TITLE
Added emitForLoad property to waitRef options

### DIFF
--- a/src/super/i-block/i-block.ts
+++ b/src/super/i-block/i-block.ts
@@ -110,7 +110,9 @@ import type {
 	InitLoadCb,
 
 	ParentMessage,
-	UnsafeIBlock
+	UnsafeIBlock,
+
+	WaitRefOptions
 
 } from 'super/i-block/interface';
 
@@ -2389,7 +2391,7 @@ export default abstract class iBlock extends ComponentInterface {
 	 * @param [opts] - additional options
 	 */
 	@p({replace: false})
-	protected waitRef<T = CanArray<iBlock | Element>>(ref: string, opts?: AsyncOptions): Promise<T> {
+	protected waitRef<T = CanArray<iBlock | Element>>(ref: string, opts?: WaitRefOptions): Promise<T> {
 		let
 			that = <iBlock>this;
 
@@ -2410,6 +2412,15 @@ export default abstract class iBlock extends ComponentInterface {
 
 			} else {
 				watchers?.push(resolve);
+
+				if (opts?.emitForLoad != null) {
+					if (Object.isString(opts.emitForLoad)) {
+						this.localEmitter.emit(opts.emitForLoad);
+
+					} else if (Object.isFunction(opts.emitForLoad)) {
+						opts.emitForLoad();
+					}
+				}
 			}
 		}), opts);
 	}

--- a/src/super/i-block/interface.ts
+++ b/src/super/i-block/interface.ts
@@ -8,6 +8,7 @@
 
 import type iBlock from 'super/i-block/i-block';
 
+import type { AsyncOptions } from 'core/async';
 import type { UnsafeComponentInterface } from 'core/component';
 import type { statuses } from 'super/i-block/const';
 
@@ -139,4 +140,8 @@ export interface UnsafeIBlock<CTX extends iBlock = iBlock> extends UnsafeCompone
 
 	// @ts-ignore (access)
 	waitRef: CTX['waitRef'];
+}
+
+export interface WaitRefOptions extends AsyncOptions {
+	emitForLoad: string | CallableFunction;
 }


### PR DESCRIPTION
это концепт - сомневаюсь по поводу названий свойств и вообще. Просьба поднакинуть - я тогда дооформлю. 
Суть реквеста в том, чтобы дать возможность одновременно с вызовом `waitRef` бросать событие, необходимое для загрузки компонента через `loadModules`: 
```

+= self.loadModules('base/b-bottom-slide', { &
	wait: "localEmitter.promisifyOnce.bind(null, 'b-bottom-slide')"
}) 

+= self.loadModules('base/b-something-else', { &
	wait: "globalEmitter.promisifyOnce.bind(null, 'b-something-else')"
}) 

...

const bottomSlite = await this.waitRef('b-bottom-slide', {emitForLoad: 'b-bottom-slide'});

const somethingElse = this.waitRef('b-something-else', {emitForLoad: () => this.globalEmitter.emit('b-something-else')});
```