### PR TITLE
Fixed an issue with test command did not wait for build operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.15.5 (2021-01-24)
+
+#### :bug: Bug Fix
+
+* Fixed an issue with test command `test:component:build` did not wait for the completion of the project build operation `build/gulp/test`
+
 ## v3.15.4 (2021-01-24)
 
 #### :boom: Breaking Change

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.15.5 (2021-01-24)
+
+#### :bug: Bug Fix
+
+* Fixed an issue with test command `test:component:build` did not wait for the completion of the project build operation
+
 ## v3.10.0 (2021-11-16)
 
 #### :rocket: New Feature

--- a/build/gulp/test.js
+++ b/build/gulp/test.js
@@ -145,9 +145,18 @@ module.exports = function init(gulp = require('gulp')) {
 
 		console.log(`webpack version: ${require('webpack/package.json').version}`);
 
-		return $.run(`npx webpack ${argsString} ${suitArg} ${extraArgs}`, {verbosity: 3})
-			.exec()
-			.on('error', console.error);
+		const
+			cmdString = `npx webpack ${argsString} ${suitArg} ${extraArgs}`;
+
+		const promisifyRun = new Promise((res, rej) => $.run(cmdString, {verbosity: 3}).exec('', (err) => {
+			if (err != null) {
+				rej(err);
+			}
+
+			res();
+		}));
+
+		return promisifyRun;
 	});
 
 	/**


### PR DESCRIPTION
Сабж: билд компонентых тестов выполнялся параллельно запуску тестов, почему тесты работают - сказать сложно )
Этот PR делает build опять нормально работающим

[Раньше Finished 'test:component:build' after 1.25 min](https://github.com/V4Fire/Client/runs/4310678389?
check_suite_focus=true)
[Cейчас Finished 'test:component:build' after 182 ms](https://github.com/V4Fire/Client/runs/4921099033?check_suite_focus=true)