### PR TITLE
improvement of end alignment in b-slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.51.1 (2023-06-27)
+
+#### :bug: Bug Fix
+
+* Handle unsuitable `pathParams` values in the `fillRouteParams` function `bRouter`
+
 ## v3.46.4 (2023-05-05)
 
 #### :bug: Bug Fix

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/index.js",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "3.46.4",
+  "version": "3.46.5-beta.1",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/base/b-router/CHANGELOG.md
+++ b/src/base/b-router/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.51.1 (2023-06-27)
+
+#### :bug: Bug Fix
+
+* Handle unsuitable `pathParams` values in the `fillRouteParams` function
+
 ## v3.44.3 (2023-03-30)
 
 #### :bug: [Bug Fix]

--- a/src/base/b-router/modules/normalizers.ts
+++ b/src/base/b-router/modules/normalizers.ts
@@ -25,7 +25,9 @@ export function fillRouteParams(route: AppliedRoute, router: bRouter): void {
 		pathParams
 	} = route;
 
-	Object.assign(params, resolvePathParameters(pathParams, params));
+	if (Object.isArray(pathParams)) {
+		Object.assign(params, resolvePathParameters(pathParams, params));
+	}
 
 	const defs: Array<[CanUndef<Dictionary>, Dictionary]> = [
 		[meta.query, query],

--- a/src/base/b-slider/CHANGELOG.md
+++ b/src/base/b-slider/CHANGELOG.md
@@ -9,6 +9,17 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v?.?.? (????-??-??)
+
+#### :boom: Breaking Change
+
+* Added new prop `alignLastToEnd` which is similar to existing `alignFirstToStart` and is also `true` by default.
+
+#### :bug: Bug Fix
+
+* Fixed incorrect `align="end"` behaviour
+
+
 ## v3.44.2 (2023-03-29)
 
 #### :house: Internal

--- a/src/base/b-slider/README.md
+++ b/src/base/b-slider/README.md
@@ -149,6 +149,10 @@ For example, by specifying `center`, the slider will stop when the active slide 
 
 If true, the first slide will be aligned to the start position (the left bound).
 
+#### [alignLastToEnd = `true`]
+
+If true, the last slide will be aligned to the end position (the right bound).
+
 #### [deltaX = `0.9`]
 
 This prop controls how much does the shift along the X-axis corresponds to a finger movement.

--- a/src/base/b-slider/b-slider.ts
+++ b/src/base/b-slider/b-slider.ts
@@ -104,6 +104,12 @@ class bSlider extends iData implements iObserveDOM, iItems {
 	readonly alignFirstToStart: boolean = true;
 
 	/**
+	 * If true, the last slide will be aligned to the end position (the right bound).
+	 */
+	@prop(Boolean)
+	readonly alignLastToEnd: boolean = true;
+
+	/**
 	 * How much does the shift along the X-axis corresponds to a finger movement
 	 */
 	@prop({type: Number, validator: (v) => Number.isPositiveBetweenZeroAndOne(v)})
@@ -271,6 +277,10 @@ class bSlider extends iData implements iObserveDOM, iItems {
 			return 0;
 		}
 
+		if (current === slideRects.length - 1 && this.alignLastToEnd) {
+			return slideRect.offsetLeft + slideRect.width - viewRect.width;
+		}
+
 		switch (align) {
 			case 'center':
 				return slideRect.offsetLeft - (viewRect.width - slideRect.width) / 2;
@@ -279,7 +289,7 @@ class bSlider extends iData implements iObserveDOM, iItems {
 				return slideRect.offsetLeft;
 
 			case 'end':
-				return slideRect.offsetLeft + slideRect.width;
+				return slideRect.offsetLeft + slideRect.width - viewRect.width;
 
 			default:
 				return 0;


### PR DESCRIPTION
- add new `alignLastToEnd` prop;
- fix align="end" behaviour