### PR TITLE
fix(b-bottom-slide): remove beforeDestroy hook

### DIFF
--- a/src/components/base/b-bottom-slide/b-bottom-slide.ts
+++ b/src/components/base/b-bottom-slide/b-bottom-slide.ts
@@ -435,16 +435,6 @@ class bBottomSlide extends iBottomSlideProps implements iLockPageScroll, iObserv
 	}
 
 	/**
-	 * Removes the component element from the DOM if its transition is complete
-	 */
-	@hook('beforeDestroy')
-	protected removeFromDOMIfPossible(): void {
-		if (!this.isStepTransitionInProgress) {
-			this.$el?.remove();
-		}
-	}
-
-	/**
 	 * Handler: the component history was cleared
 	 */
 	@watch(':history:clear')


### PR DESCRIPTION
This hook is not needed anymore as we are now using Vue teleport.