### PR TITLE
Фикс бага метода lock трейта iLockPageScroll

### DIFF
--- a/src/traits/i-lock-page-scroll/CHANGELOG.md
+++ b/src/traits/i-lock-page-scroll/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v??.??.?? (2023-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed a bug with resolving a promise returned by the `iLockPageScroll.lock`
+
 ## v3.0.0-rc.199 (2021-06-16)
 
 #### :bug: Bug Fix

--- a/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
+++ b/src/traits/i-lock-page-scroll/i-lock-page-scroll.ts
@@ -42,6 +42,7 @@ export default abstract class iLockPageScroll {
 		}
 
 		const lockLabel = {
+			join: true,
 			group,
 			label: $$.lock
 		};
@@ -120,7 +121,7 @@ export default abstract class iLockPageScroll {
 					res();
 
 				}, lockLabel);
-			}), {join: true, ...lockLabel});
+			}), lockLabel);
 
 		} else {
 			promise = $a.promise(new Promise((res) => {
@@ -139,7 +140,7 @@ export default abstract class iLockPageScroll {
 					res();
 
 				}, lockLabel);
-			}), {join: true, ...lockLabel});
+			}), lockLabel);
 		}
 
 		return promise;


### PR DESCRIPTION
Из за того что возвращаемый lock методом промис обернут с параметром join: true, а requestAnimationFrame вызывается без этого параметра, то повторный вызов lock, до того как сработает коллбек requestAnimationFrame, уничтожит старый поток requestAnimationFrame, но из-за join: true метод lock вернет старый промис, который никогда не зарезолвится, тк вызов коллбека resolve происходил в коллбеке прошлого requestAnimationFrame