### PR TITLE
Givanyan99/ds deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,6 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 #### :rocket: New Feature
 
 * Improved display of warnings about deprecated design system fields `build/stylus/ds`
-
-## v4.??.?? (2023-??-??)
-
-#### :rocket: New Feature
-
 * Added possibility to change the method that will be used for transitions when the router
   synchronizes its state with the component's state by using `syncRouterState` `iBlock`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :rocket: New Feature
 
+* Improved display of warnings about deprecated design system fields `build/stylus/ds`
+
+## v4.??.?? (2023-??-??)
+
+#### :rocket: New Feature
+
 * Added possibility to change the method that will be used for transitions when the router
   synchronizes its state with the component's state by using `syncRouterState` `iBlock`
 

--- a/build/stylus/ds/CHANGELOG.md
+++ b/build/stylus/ds/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.??.?? (2023-??-??)
+
+#### :rocket: New Feature
+
+* Improved display of warnings about deprecated design system fields
+
 ## v3.46.4 (2023-05-05)
 
 #### :bug: Bug Fix

--- a/build/stylus/ds/helpers.js
+++ b/build/stylus/ds/helpers.js
@@ -256,7 +256,8 @@ function checkDeprecated(ds, path) {
 	}
 
 	const
-		strPath = Object.isString(path) ? path : path.join('.'),
+		[field] = Object.isString(path) ? path.match(/[^.]+/) : path,
+		strPath = Object.isString(path) ? path.replace(/.*?\./, '') : path.slice(1).join('.'),
 		deprecated = ds.meta.deprecated[strPath];
 
 	if (deprecated == null) {
@@ -269,13 +270,13 @@ function checkDeprecated(ds, path) {
 	if (Object.isDictionary(deprecated)) {
 		if (deprecated.renamedTo != null) {
 			message.push(
-				`[stylus] Warning: design system field by path "${strPath}" was renamed to "${deprecated.renamedTo}".`,
+				`[stylus] Warning: design system field "${field}" by path "${strPath}" was renamed to "${deprecated.renamedTo}".`,
 				'Please use the renamed version instead of the current, because it will be removed from the next major release.'
 			);
 
 		} else if (deprecated.alternative != null) {
 			message.push(
-				`[stylus] Warning: design system field by path "${strPath}" was deprecated and will be removed from the next major release.`
+				`[stylus] Warning: design system field "${field}" by path "${strPath}" was deprecated and will be removed from the next major release.`
 			);
 
 			message.push(`Please use "${deprecated.alternative}" instead.`);
@@ -287,7 +288,7 @@ function checkDeprecated(ds, path) {
 
 	} else {
 		message.push(
-			`[stylus] Warning: design system field by path "${strPath}" was deprecated and will be removed from the next major release.`
+			`[stylus] Warning: design system field "${field}" by path "${strPath}" was deprecated and will be removed from the next major release.`
 		);
 	}
 


### PR DESCRIPTION
Сейчас чтобы указать устаревшее поле в ds нужно прописывать полный путь `colors.Text.Primary`

Это не очень удобно и может вызывать вопросы тк в коде используется токен `Text.Primary`

Поэтому теперь контекст в котором используется токен отделяется от пути и выводится в сообщении отдельно