### PR TITLE
Setup webpack managed paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.??.?? (2023-??-??)
+
+#### :rocket: New Feature
+
+* Webpack build helpers
+  * Added `getManagedPath` helper, which generates managed path for node_modules with excludes
+  * Added `prepareLibsForRegExp` helper, which converts list of library names to a regexp string
+  * Added `createDepRegExp` helper, which create a regexp matching all deps except excluded
+
+* Config
+  * Added `managed-libs` option, which add specified libraries to `snapshot.managedPaths` and watches
+  them in webpack watch mode
+
 ## v4.0.0-beta.12 (2023-08-21)
 
 #### :bug: Bug Fix

--- a/build/helpers/CHANGELOG.md
+++ b/build/helpers/CHANGELOG.md
@@ -9,6 +9,14 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.??.?? (2023-??-??)
+
+#### :rocket: New Feature
+
+* Added `getManagedPath` helper, which generates managed path for node_modules with excludes
+* Added `prepareLibsForRegExp` helper, which converts list of library names to a regexp string
+* Added `createDepRegExp` helper, which create a regexp matching all deps except excluded
+
 ## v3.47.3 (2023-05-26)
 
 #### :rocket: New Feature

--- a/build/helpers/webpack.js
+++ b/build/helpers/webpack.js
@@ -112,9 +112,9 @@ exports.getManagedPath = getManagedPath;
  * @returns {RegExp}
  * @example
  * ```js
- * getManagedPaths(['@v4fire/client', '@v4fire/core'])
+ * getManagedPath(['@v4fire/client', '@v4fire/core'])
  * // or
- * getManagedPaths('@v4fire[\\\\/]client|@v4fire[\\\\/]core')
+ * getManagedPath('@v4fire[\\\\/]client|@v4fire[\\\\/]core')
  * ```
  */
 function getManagedPath(exclude) {
@@ -131,7 +131,7 @@ exports.prepareLibsForRegExp = prepareLibsForRegExp;
  * @returns {string}
  * @example
  * ```js
- * prepareLibListForRegexp(['@v4fire/client', '@v4fire/core']) // '@v4fire[\\\\/]client|@v4fire[\\\\/]core'
+ * prepareLibsForRegExp(['@v4fire/client', '@v4fire/core']) // '@v4fire[\\\\/]client|@v4fire[\\\\/]core'
  * ```
  */
 function prepareLibsForRegExp(libs) {

--- a/build/webpack/CHANGELOG.md
+++ b/build/webpack/CHANGELOG.md
@@ -9,16 +9,6 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v4.??.?? (2023-??-??)
-
-* Added `getManagedPath` helper, which generates managed path for node_modules with excludes
-* Added `prepareLibsForRegExp` helper, which converts list of library names to a regexp string
-* Added `createDepRegExp` helper, which create a regexp matching all deps except excluded
-
-#### :rocket: New Feature
-
-* Added a new plugin `i18n-plugin`
-
 ## v3.42.0 (2023-03-14)
 
 #### :bug: Bug Fix

--- a/build/webpack/CHANGELOG.md
+++ b/build/webpack/CHANGELOG.md
@@ -9,6 +9,16 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.??.?? (2023-??-??)
+
+* Added `getManagedPath` helper, which generates managed path for node_modules with excludes
+* Added `prepareLibsForRegExp` helper, which converts list of library names to a regexp string
+* Added `createDepRegExp` helper, which create a regexp matching all deps except excluded
+
+#### :rocket: New Feature
+
+* Added a new plugin `i18n-plugin`
+
 ## v3.42.0 (2023-03-14)
 
 #### :bug: Bug Fix

--- a/build/webpack/snapshot.js
+++ b/build/webpack/snapshot.js
@@ -17,7 +17,7 @@ const exclude = [
 	depsRgxpStr,
 	prepareLibsForRegExp(webpack.managedLibs())
 ]
-	.filter((str) => str !== '')
+	.filter(Boolean)
 	.join('|');
 
 /**

--- a/build/webpack/snapshot.js
+++ b/build/webpack/snapshot.js
@@ -8,9 +8,25 @@
 
 'use strict';
 
+const
+	{webpack} = require('@config/config'),
+	{getManagedPath, prepareLibsForRegExp} = include('build/helpers'),
+	{depsRgxpStr} = include('build/const');
+
+const exclude = [
+	depsRgxpStr,
+	prepareLibsForRegExp(webpack.managedLibs())
+]
+	.filter((str) => str !== '')
+	.join('|');
+
 /**
  * Options for `webpack.snapshot`
  */
 module.exports = {
-	...IS_PROD ? {} : {managedPaths: []}
+	...IS_PROD ?
+		{} :
+		{
+			managedPaths: [getManagedPath(exclude)]
+		}
 };

--- a/build/webpack/watch-options.js
+++ b/build/webpack/watch-options.js
@@ -9,7 +9,16 @@
 'use strict';
 
 const
-	{isExternalDep} = include('build/const');
+	{webpack} = require('@config/config'),
+	{depsRgxpStr} = include('build/const'),
+	{createDepRegExp, prepareLibsForRegExp} = include('build/helpers');
+
+const exclude = [
+	depsRgxpStr,
+	prepareLibsForRegExp(webpack.managedLibs())
+]
+	.filter((str) => str !== '')
+	.join('|');
 
 /**
  * Options for `webpack.watchOptions`
@@ -17,5 +26,5 @@ const
 module.exports = {
 	aggregateTimeout: 200,
 	poll: 1000,
-	ignored: isExternalDep
+	ignored: createDepRegExp(exclude)
 };

--- a/build/webpack/watch-options.js
+++ b/build/webpack/watch-options.js
@@ -17,7 +17,7 @@ const exclude = [
 	depsRgxpStr,
 	prepareLibsForRegExp(webpack.managedLibs())
 ]
-	.filter((str) => str !== '')
+	.filter(Boolean)
 	.join('|');
 
 /**

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.??.?? (2023-??-??)
+
+#### :rocker: New Feature
+
+* Added `managed-libs` option, which add specified libraries to `snapshot.managedPaths` and watches
+them in webpack watch mode
+
 ## v3.39.0 (2023-03-07)
 
 #### :rocket: New Feature

--- a/config/default.js
+++ b/config/default.js
@@ -457,6 +457,29 @@ module.exports = config.createConfig({dirs: [__dirname, 'client']}, {
 		},
 
 		/**
+		 * This option should be used to specify managed libs, which will
+		 * be excluded from `snapshot.managedPaths` and from `watchOptions.ignore`.
+		 *
+		 * @cli managed-libs
+		 * @env MANAGED_LIBS
+		 *
+		 * @example
+		 * ```bash
+		 * npx webpack --env managed-libs="@scope/helpers,@scope/core"
+		 * ```
+		 *
+		 * @returns {string[]}
+		 */
+		managedLibs() {
+			return o('managed-libs', {
+				env: true,
+				default: ''
+			})
+				.split(',')
+				.map((str) => str.trim());
+		},
+
+		/**
 		 * Returns the `webpack.aliases` value
 		 *
 		 * @see https://webpack.js.org/configuration/resolve/#resolvealias

--- a/config/default.js
+++ b/config/default.js
@@ -458,7 +458,7 @@ module.exports = config.createConfig({dirs: [__dirname, 'client']}, {
 
 		/**
 		 * This option should be used to specify managed libs, which will
-		 * be excluded from `snapshot.managedPaths` and from `watchOptions.ignore`.
+		 * be excluded from `snapshot.managedPaths` and from `watchOptions.ignore`
 		 *
 		 * @cli managed-libs
 		 * @env MANAGED_LIBS


### PR DESCRIPTION
Этот PR добавляет env переменную `managed-libs`, которая позволяет указать дополнительные библиотеки (помимо слоев) для исключения из кэша и ватчинга.

Также был настроен `snapshot.managedPaths`, который исключает из кэша слои, но при этом кэширует остальные зависимости из node_modules.