### PR TITLE
chore(tag-name): fix rootTag behavior in snakeskin

### DIFF
--- a/build/snakeskin/filters/tag-name.js
+++ b/build/snakeskin/filters/tag-name.js
@@ -35,11 +35,7 @@ module.exports = [
 	 */
 	function expandRootTag(tag, attrs, rootTag) {
 		if (tag === '_') {
-			if (rootTag) {
-				return rootTag;
-			}
-
-			const tag = ["rootTag || 'div'"];
+			const tag = rootTag ? [JSON.stringify(rootTag)] : ["rootTag || 'div'"];
 			attrs['v-tag'] = tag;
 
 			if (webpack.ssr) {


### PR DESCRIPTION
Always create an element with v-tag directive
to be consistent with rootTag prop