### PR TITLE
Смена подключения стилей с скриптов с тегов на скрипт

### DIFF
--- a/src/components/super/i-static-page/modules/ss-helpers/page.js
+++ b/src/components/super/i-static-page/modules/ss-helpers/page.js
@@ -165,7 +165,7 @@ function getScriptDeclByName(name, {
 		decl = getScriptDecl({
 			...defAttrs,
 			defer,
-			js: !externalizeInitial,
+			js: externalizeInitial,
 			src: externalizeInitial ? assets[name].publicPath : addPublicPath([`PATH['${name}']`])
 		});
 
@@ -236,7 +236,7 @@ function getStyleDeclByName(name, {
 		decl = getStyleDecl({
 			...defAttrs,
 			defer,
-			js: !externalizeInitial,
+			js: externalizeInitial,
 			rel: 'stylesheet',
 			src: externalizeInitial ? assets[rname].publicPath : addPublicPath([`PATH['${rname}']`])
 		});

--- a/src/components/super/i-static-page/modules/ss-helpers/page.js
+++ b/src/components/super/i-static-page/modules/ss-helpers/page.js
@@ -236,7 +236,7 @@ function getStyleDeclByName(name, {
 		decl = getStyleDecl({
 			...defAttrs,
 			defer,
-			js: externalizeInitial,
+			js,
 			rel: 'stylesheet',
 			src: externalizeInitial ? assets[rname].publicPath : addPublicPath([`PATH['${rname}']`])
 		});


### PR DESCRIPTION
Сейчас в файле `touch_ES2019_p-root.init.js` получается микс из js-кода и HTML-тегов:
```javascript
(function () {
	var el = document.createElement('script');
	el.async = false;
	el.setAttribute('src', 'touch_ES2019_lib/vue.js');
	document.head.appendChild(el);
})();

<script src="touch_ES2019_index-core.js" defer></script>
<script src="touch_ES2019_vendor.js" defer></script>
<script src="touch_ES2019_p-root_tpl.js" defer></script>
<script src="touch_ES2019_p-root.js" defer></script>
```
Необходимо чтобы был только js-код.
В этом PR меняю значение атрибута от которого зависит как будет подключен файл: через тег или через js.

Необходимо чтобы в файле `p-root.html` были HTML-теги, а в файле `touch_ES2019_p-root.init.js` — js-код.