### PR TITLE
Intersection-watcher unit test updates (Issues/1017)

### DIFF
--- a/src/core/dom/intersection-watcher/test/unit/options.ts
+++ b/src/core/dom/intersection-watcher/test/unit/options.ts
@@ -85,7 +85,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 						});
 					}, {target, wasInvoked});
 
-					// Scroll vertically by the full target height, wait 100ms
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					// Go back to the top
@@ -107,7 +107,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 						});
 					}, {target, intersectionTimes});
 
-					// Scroll vertically by the full target height and then go back to the top after 200ms several times
+					// Scrolling vertically by the full target height and then go back to the top several times
 					let scrollTries = 3;
 					while (scrollTries > 0) {
 						scrollTries -= 1;
@@ -126,7 +126,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 				].join(' '),
 
 				async ({page}) => {
-					// Move the target outside the viewport
+					// Moving the target outside the viewport
 					await target.evaluate((element) => {
 						element.style.marginLeft = '100%';
 					});
@@ -137,13 +137,13 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 						});
 					}, {target, wasInvoked});
 
-					// Scroll by the 80% of the target height and width
+					// Scrolling by the 80% of the target height and width
 					// Now the 64% of a target area is in the viewport: 0.8h by 0.8w
 					await scrollBy(page, {top: 80, left: 80, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 
-					// Scroll horizontally by the 20% of the target width
+					// Scrolling horizontally by the 20% of the target width
 					// Now the 80% of a target area is in the viewport: 0.8h by 1w
 					await scrollBy(page, {left: 20, delay: 200});
 
@@ -175,7 +175,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 						});
 					}, {target, intersectionResults});
 
-					// Scroll vertically by 50% of the target height, wait 500ms
+					// Scrolling vertically by 50% of the target height, wait 500ms
 					await scrollBy(page, {top: 50, delay: 500});
 
 					// Go back to the top
@@ -212,7 +212,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							observer.watch(target, {onEnter}, handler);
 						}), target);
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100});
 
 					test.expect(await watchPromise).toMatchObject(['onEnter', 'handler']);
@@ -229,7 +229,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 						});
 					}, {target, wasInvoked});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
@@ -251,7 +251,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							observer.watch(target, {delay, onEnter}, (watcher) => watcher);
 						}), {target, delay});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100});
 
 					test.expect(await watchPromise).toBeLessThan(delay);
@@ -267,7 +267,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							observer.watch(target, {onLeave: resolve}, (watcher) => watcher);
 						}), target);
 
-					// Scroll vertically by the full target height, wait 200ms
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					// Go back to the top
@@ -292,7 +292,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							observer.watch(target, {delay, onLeave}, (watcher) => watcher);
 						}), {target, delay});
 
-					// Scroll vertically by the full target height, wait 200ms
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					// Go back to the top

--- a/src/core/dom/intersection-watcher/test/unit/options.ts
+++ b/src/core/dom/intersection-watcher/test/unit/options.ts
@@ -86,10 +86,10 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					}, {target, wasInvoked});
 
 					// Scroll vertically by the full target height, wait 100ms
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					// Go back to the top
-					await scrollBy(page, {top: -100, delay: 100});
+					await scrollBy(page, {top: -100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 				}
@@ -139,13 +139,13 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 
 					// Scroll by the 80% of the target height and width
 					// Now the 64% of a target area is in the viewport: 0.8h by 0.8w
-					await scrollBy(page, {top: 80, left: 80, delay: 100});
+					await scrollBy(page, {top: 80, left: 80, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 
 					// Scroll horizontally by the 20% of the target width
 					// Now the 80% of a target area is in the viewport: 0.8h by 1w
-					await scrollBy(page, {left: 20, delay: 100});
+					await scrollBy(page, {left: 20, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, true);
 				}
@@ -230,7 +230,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					}, {target, wasInvoked});
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 				}

--- a/src/core/dom/intersection-watcher/test/unit/root.ts
+++ b/src/core/dom/intersection-watcher/test/unit/root.ts
@@ -47,9 +47,6 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 		rootInner = await createElement(page, ROOT_INNER_STYLES, root);
 		target = await createElement(page, TARGET_STYLES, rootInner);
 
-		// Scrolling until the root element is entirely in the viewport
-		await scrollBy(page, {top: 300});
-
 		IntersectionObserverModule = await Utils.import(page, 'core/dom/intersection-watcher/engines/intersection-observer.ts');
 		intersectionObserver = await IntersectionObserverModule.evaluateHandle(({default: Observer}) => new Observer());
 
@@ -77,6 +74,9 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							observer.watch(target, {root}, resolve);
 						}), {root, target});
 
+					// Scrolling until the root element is entirely in the viewport
+					await scrollBy(page, {top: 300, delay: 200});
+
 					// Scrolling the root element so that the target is in the root view
 					await scrollBy(page, {top: 100, left: 100}, root);
 
@@ -94,7 +94,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					await page.evaluate((target) => {
 						Object.assign(target.style, {
 							position: 'absolute',
-							top: '400px'
+							top: '300px'
 						});
 					}, target);
 
@@ -103,6 +103,9 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							intersectionCount.count += 1;
 						});
 					}, {root, target, intersectionCount});
+
+					// Scrolling until the root element is entirely in the viewport
+					await scrollBy(page, {top: 300, delay: 200});
 
 					// Scrolling vertically so that the target is in the root view
 					await scrollBy(page, {top: 200, delay: 200}, root);
@@ -142,6 +145,9 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 							intersectionCount.count += 1;
 						});
 					}, {root, target, intersectionCount});
+
+					// Scrolling until the root element is entirely in the viewport
+					await scrollBy(page, {top: 300, delay: 200});
 
 					// Scrolling vertically so that the target is in the root view
 					await scrollBy(page, {top: 200, delay: 200}, root);

--- a/src/core/dom/intersection-watcher/test/unit/root.ts
+++ b/src/core/dom/intersection-watcher/test/unit/root.ts
@@ -105,14 +105,14 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					}, {root, target, intersectionCount});
 
 					// Scrolling vertically so that the target is in the root view
-					await scrollBy(page, {top: 200, delay: 100}, root);
+					await scrollBy(page, {top: 200, delay: 200}, root);
 
 					// Scrolling the page by the full height of the root element
 					// so that both the root and the target are out of the viewport
-					await scrollBy(page, {top: -300, delay: 100});
+					await scrollBy(page, {top: -300, delay: 200});
 
 					// Both the root and the target are in the viewport again
-					await scrollBy(page, {top: 300, delay: 100});
+					await scrollBy(page, {top: 300, delay: 200});
 
 					test.expect(await intersectionCount.evaluate(({count}) => count)).toBe(1);
 				}
@@ -144,14 +144,14 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					}, {root, target, intersectionCount});
 
 					// Scrolling vertically so that the target is in the root view
-					await scrollBy(page, {top: 200, delay: 100}, root);
+					await scrollBy(page, {top: 200, delay: 200}, root);
 
 					// Scrolling the page by the full height of the root element
 					// so that both the root and the target are out of the viewport
-					await scrollBy(page, {top: -300, delay: 100});
+					await scrollBy(page, {top: -300, delay: 200});
 
 					// Both the root and the target are in the viewport again
-					await scrollBy(page, {top: 300, delay: 100});
+					await scrollBy(page, {top: 300, delay: 200});
 
 					test.expect(await intersectionCount.evaluate(({count}) => count)).toBe(2);
 				}

--- a/src/core/dom/intersection-watcher/test/unit/root.ts
+++ b/src/core/dom/intersection-watcher/test/unit/root.ts
@@ -128,7 +128,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 				].join(' '),
 
 				async ({page}) => {
-					test.skip(engine === 'intersection');
+					test.skip(engine === 'intersection', 'the intersection-observer strategy does not have the onlyRoot option');
 
 					const intersectionCount = await page.evaluateHandle(() => ({count: 0}));
 
@@ -136,7 +136,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection with
 					await page.evaluate((target) => {
 						Object.assign(target.style, {
 							position: 'absolute',
-							top: '400px'
+							top: '300px'
 						});
 					}, target);
 

--- a/src/core/dom/intersection-watcher/test/unit/unwatch.ts
+++ b/src/core/dom/intersection-watcher/test/unit/unwatch.ts
@@ -67,7 +67,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 						observer.unwatch(target);
 					}, {target, wasInvoked});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
@@ -94,7 +94,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 						observer.unwatch(target, handlers[1]);
 					}, {target, intersectionResults});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					test.expect(await intersectionResults.evaluate((results) => results)).not.toContain('second');
@@ -123,7 +123,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 						observer.unwatch(target, 0.5);
 					}, {target, intersectionResults});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					test.expect(await intersectionResults.evaluate((results) => results)).not.toContain(0.5);
@@ -144,7 +144,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 						observer.unwatch();
 					}, {target, wasInvoked});
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
@@ -174,7 +174,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 							}
 						}), target);
 
-					// Scroll vertically by the full target height
+					// Scrolling vertically by the full target height
 					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);

--- a/src/core/dom/intersection-watcher/test/unit/unwatch.ts
+++ b/src/core/dom/intersection-watcher/test/unit/unwatch.ts
@@ -68,7 +68,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 					}, {target, wasInvoked});
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 				}
@@ -95,7 +95,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 					}, {target, intersectionResults});
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					test.expect(await intersectionResults.evaluate((results) => results)).not.toContain('second');
 
@@ -124,7 +124,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 					}, {target, intersectionResults});
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					test.expect(await intersectionResults.evaluate((results) => results)).not.toContain(0.5);
 
@@ -145,7 +145,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 					}, {target, wasInvoked});
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 				}
@@ -175,7 +175,7 @@ test.describe('core/dom/intersection-watcher: cancelling watching for the inters
 						}), target);
 
 					// Scroll vertically by the full target height
-					await scrollBy(page, {top: 100, delay: 100});
+					await scrollBy(page, {top: 100, delay: 200});
 
 					await assertWasInvokedIs(wasInvoked, false);
 

--- a/src/core/dom/intersection-watcher/test/unit/watch.ts
+++ b/src/core/dom/intersection-watcher/test/unit/watch.ts
@@ -78,7 +78,7 @@ test.describe('core/dom/intersection-watcher: watching for the intersection of a
 						observer.watch(target, resolve);
 					}), target);
 
-					// Scroll vertically by the full target height (default `threshold` option value is 1)
+					// Scrolling vertically by the full target height (default `threshold` option value is `1`)
 					await scrollBy(page, {top: 100});
 
 					await test.expect(watchPromise).toBeResolved();


### PR DESCRIPTION
Добавлены тест-кейсы, покрывающие случаи, описанные в issue #1017 (одновременное наблюдение нескольких элементов, расположенных на странице определённым образом).
Скорректирован порядок запуска тест-кейсов с заданным root-элементом, увеличены временные задержки после скроллинга (предотвращение race conditions).