### PR TITLE
Add missing methods to friend classes (block, dom) prototypes

### DIFF
--- a/src/components/base/b-sidebar/b-sidebar.ts
+++ b/src/components/base/b-sidebar/b-sidebar.ts
@@ -13,6 +13,8 @@
 
 import { derive } from 'core/functools/trait';
 
+import Block, { getElementSelector } from 'components/friends/block';
+
 import iVisible from 'components/traits/i-visible/i-visible';
 import iOpenToggle, { CloseHelperEvents } from 'components/traits/i-open-toggle/i-open-toggle';
 import iLockPageScroll from 'components/traits/i-lock-page-scroll/i-lock-page-scroll';
@@ -21,6 +23,8 @@ import iData, { component, hook, prop, ModsDecl } from 'components/super/i-data/
 
 export * from 'components/super/i-data/i-data';
 export * from 'components/traits/i-open-toggle/i-open-toggle';
+
+Block.addToPrototype({getElementSelector});
 
 interface bSidebar extends Trait<typeof iOpenToggle>, Trait<typeof iLockPageScroll> {}
 

--- a/src/components/base/b-tree/b-tree.ts
+++ b/src/components/base/b-tree/b-tree.ts
@@ -17,7 +17,7 @@ import SyncPromise from 'core/promise/sync';
 import { derive } from 'core/functools/trait';
 
 import AsyncRender, { iterate, TaskOptions } from 'components/friends/async-render';
-import Block, { getElementMod, setElementMod } from 'components/friends/block';
+import Block, { getElementMod, setElementMod, getElementSelector } from 'components/friends/block';
 import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems from 'components/traits/i-items/i-items';
@@ -37,7 +37,7 @@ export * from 'components/super/i-data/i-data';
 export * from 'components/base/b-tree/interface';
 
 AsyncRender.addToPrototype({iterate});
-Block.addToPrototype({getElementMod, setElementMod});
+Block.addToPrototype({getElementMod, setElementMod, getElementSelector});
 DOM.addToPrototype({delegateElement});
 
 const

--- a/src/components/base/b-tree/b-tree.ts
+++ b/src/components/base/b-tree/b-tree.ts
@@ -17,7 +17,7 @@ import SyncPromise from 'core/promise/sync';
 import { derive } from 'core/functools/trait';
 
 import AsyncRender, { iterate, TaskOptions } from 'components/friends/async-render';
-import Block, { getElementMod, setElementMod, getElementSelector } from 'components/friends/block';
+import Block, { getElementMod, setElementMod, getElementSelector, getFullElementName } from 'components/friends/block';
 import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems from 'components/traits/i-items/i-items';
@@ -37,7 +37,7 @@ export * from 'components/super/i-data/i-data';
 export * from 'components/base/b-tree/interface';
 
 AsyncRender.addToPrototype({iterate});
-Block.addToPrototype({getElementMod, setElementMod, getElementSelector});
+Block.addToPrototype({getElementMod, setElementMod, getElementSelector, getFullElementName});
 DOM.addToPrototype({delegateElement});
 
 const

--- a/src/components/base/b-tree/b-tree.ts
+++ b/src/components/base/b-tree/b-tree.ts
@@ -18,6 +18,7 @@ import { derive } from 'core/functools/trait';
 
 import AsyncRender, { iterate, TaskOptions } from 'components/friends/async-render';
 import Block, { getElementMod, setElementMod } from 'components/friends/block';
+import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems from 'components/traits/i-items/i-items';
 import iActiveItems, { IterationKey } from 'components/traits/i-active-items/i-active-items';
@@ -37,6 +38,7 @@ export * from 'components/base/b-tree/interface';
 
 AsyncRender.addToPrototype({iterate});
 Block.addToPrototype({getElementMod, setElementMod});
+DOM.addToPrototype({delegateElement});
 
 const
 	$$ = symbolGenerator();

--- a/src/components/form/b-select/b-select.ts
+++ b/src/components/form/b-select/b-select.ts
@@ -15,7 +15,7 @@ import SyncPromise from 'core/promise/sync';
 
 import { derive } from 'core/functools/trait';
 
-import Block, { setElementMod, removeElementMod } from 'components/friends/block';
+import Block, { setElementMod, removeElementMod, getElementSelector } from 'components/friends/block';
 import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems, { IterationKey } from 'components/traits/i-items/i-items';
@@ -61,7 +61,7 @@ export * from 'components/form/b-select/interface';
 export { Value, FormValue };
 
 DOM.addToPrototype({delegateElement});
-Block.addToPrototype({setElementMod, removeElementMod});
+Block.addToPrototype({setElementMod, removeElementMod, getElementSelector});
 Mask.addToPrototype(MaskAPI);
 
 interface bSelect extends Trait<typeof iOpenToggle>, Trait<typeof iActiveItems>, Trait<typeof SelectEventHandlers> {}

--- a/src/components/form/b-select/b-select.ts
+++ b/src/components/form/b-select/b-select.ts
@@ -16,6 +16,7 @@ import SyncPromise from 'core/promise/sync';
 import { derive } from 'core/functools/trait';
 
 import Block, { setElementMod, removeElementMod } from 'components/friends/block';
+import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems, { IterationKey } from 'components/traits/i-items/i-items';
 import iActiveItems from 'components/traits/i-active-items/i-active-items';
@@ -59,6 +60,7 @@ export * from 'components/form/b-select/interface';
 
 export { Value, FormValue };
 
+DOM.addToPrototype({delegateElement});
 Block.addToPrototype({setElementMod, removeElementMod});
 Mask.addToPrototype(MaskAPI);
 


### PR DESCRIPTION
При разработке приложения обнаружил, что есть ошибка при вызове метода `dom.delegateElement` в `b-tree`. При этом юнит-тесты в клиенте выполняются без ошибок: видимо это связано с тем, что в бандл попадает нужный метод через какой-то другой компонент.

Наши юнит-тесты не совсем надежны.