### PR TITLE
b-router unit tests refactoring (Issues/966)

### DIFF
--- a/src/components/base/b-router/test/helpers.ts
+++ b/src/components/base/b-router/test/helpers.ts
@@ -12,10 +12,11 @@ import test from 'tests/config/unit/test';
 
 import { Component, Utils } from 'tests/helpers';
 
+import type iStaticPage from 'components/super/i-static-page/i-static-page';
+
 import type { StaticRoutes } from 'core/router';
 import type { EngineName, InitRouter } from 'components/base/b-router/test/interface';
 import type { Router } from 'components/base/b-router/interface';
-import type iStaticPage from 'components/super/i-static-page/i-static-page';
 
 /**
  * Returns a function to initialize the router on the page with the specified engine, routes and props
@@ -61,7 +62,7 @@ export function createInitRouter(engineName: EngineName, routes?: StaticRoutes, 
 
 /**
  * Pushes the provided route path and checks whether the value
- * of the meta.content field matches the assertion.
+ * of the `meta.content` field matches the assertion.
  * The function returns a Promise.
  *
  * @param root

--- a/src/components/base/b-router/test/helpers.ts
+++ b/src/components/base/b-router/test/helpers.ts
@@ -6,11 +6,16 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
+import type { JSHandle } from 'playwright';
+
+import test from 'tests/config/unit/test';
+
 import { Component, Utils } from 'tests/helpers';
 
 import type { StaticRoutes } from 'core/router';
 import type { EngineName, InitRouter } from 'components/base/b-router/test/interface';
 import type { Router } from 'components/base/b-router/interface';
+import type iStaticPage from 'components/super/i-static-page/i-static-page';
 
 /**
  * Returns a function to initialize the router on the page with the specified engine, routes and props
@@ -52,4 +57,24 @@ export function createInitRouter(engineName: EngineName, routes?: StaticRoutes, 
 
 		return Component.waitForRoot(page);
 	};
+}
+
+/**
+ * Pushes the provided route path and checks whether the value
+ * of the meta.content field matches the assertion.
+ * The function returns a Promise.
+ *
+ * @param root
+ * @param path
+ * @param content
+ */
+export async function assertPathTransitionsTo(
+	root: JSHandle<iStaticPage>,
+	path: string,
+	content: string
+): Promise<void> {
+	await test.expect(root.evaluate(async (ctx, path) => {
+		await ctx.router!.push(path);
+		return ctx.route!.meta.content;
+	}, path)).toBeResolvedTo(content);
 }

--- a/src/components/base/b-router/test/helpers.ts
+++ b/src/components/base/b-router/test/helpers.ts
@@ -13,7 +13,7 @@ import type { EngineName, InitRouter } from 'components/base/b-router/test/inter
 import type { Router } from 'components/base/b-router/interface';
 
 /**
- * Returns a function to initialize the router on the page with the specified engine
+ * Returns a function to initialize the router on the page with the specified engine, routes and props
  *
  * @param engineName
  * @param [routes]
@@ -45,105 +45,9 @@ export function createInitRouter(engineName: EngineName, routes?: StaticRoutes, 
 			id: 'target',
 
 			engine,
+			routes,
 			initialRoute: initOptions.initialRoute ?? undefined,
-			...props,
-
-			routes: {
-				main: {
-					path: '/',
-					content: 'Main page'
-				},
-
-				second: {
-					// Path should not match with the page id so that we can test non-normalized path as an argument
-					path: '/second-page',
-					content: 'Second page',
-					query: {
-						rootParam: (o) => o.r.rootParam
-					}
-				},
-
-				secondAlias: {
-					path: '/second/alias',
-					alias: 'second'
-				},
-
-				aliasToAlias: {
-					path: '/alias-to-alias',
-					alias: 'secondAlias'
-				},
-
-				aliasToRedirect: {
-					path: '/second/alias-redirect',
-					alias: 'indexRedirect'
-				},
-
-				indexRedirect: {
-					path: '/redirect',
-					redirect: 'main'
-				},
-
-				secondRedirect: {
-					path: '/second/redirect',
-					redirect: 'second'
-				},
-
-				redirectToAlias: {
-					path: '/redirect-alias',
-					redirect: 'secondAlias'
-				},
-
-				redirectToRedirect: {
-					path: '/redirect-redirect',
-					redirect: 'secondRedirect'
-				},
-
-				external: {
-					path: 'https://www.google.com'
-				},
-
-				externalRedirect: {
-					path: '/external-redirect',
-					redirect: 'https://www.google.com'
-				},
-
-				localExternal: {
-					path: '/',
-					external: true
-				},
-
-				template: {
-					path: '/tpl/:param1/:param2?',
-					pathOpts: {
-						aliases: {
-							param1: ['_param1', 'Param1'],
-							param2: ['Param2']
-						}
-					}
-				},
-
-				strictTemplate: {
-					paramsFromQuery: false,
-					path: '/strict-tpl/:param1/:param2?'
-				},
-
-				templateAlias: {
-					path: '/tpl-alias/:param1/:param2?',
-					alias: 'template'
-				},
-
-				redirectTemplate: {
-					path: '/tpl/redirect/:param1/:param2',
-					redirect: 'template'
-				},
-
-				notFound: {
-					default: true,
-					content: '404'
-				},
-
-				...routes
-			}
+			...props
 		});
 
 		return Component.waitForRoot(page);

--- a/src/components/base/b-router/test/unit/links-on-page.ts
+++ b/src/components/base/b-router/test/unit/links-on-page.ts
@@ -86,99 +86,120 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test.describe('links that should not be intercepted by the router but should be intercepted by the browser', () => {
+		test(
+			'links with absolute URLs',
+
+			async ({page}) => {
 				await createInitRouter('history')(page);
 
-			await Component.createComponent(page, 'a', {
-				'data-testid': 'target',
-				href: 'https://www.google.com',
-				text: 'Go'
-			});
+				await Component.createComponent(page, 'a', {
+					'data-testid': 'target',
+					href: 'https://www.google.com',
+					text: 'Go'
+				});
 
-			await page.getByTestId('target').click();
-			test.expect(page.url()).toBe('https://www.google.com/');
-		});
+				await page.getByTestId('target').click();
+				test.expect(page.url()).toBe('https://www.google.com/');
+			}
+		);
 
-		test('anchor links', async ({page}) => {
-			const root = await createInitRouter('history', {
-				main: {
-					path: '/'
-				}
+		test(
+			'anchor links',
+
+			async ({page}) => {
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
 				})(page, {
 					initialRoute: 'main'
 				});
 
-			await Component.createComponent(page, 'a', {
-				'data-testid': 'target',
-				href: '#foo',
-				text: 'Go'
-			});
+				await Component.createComponent(page, 'a', {
+					'data-testid': 'target',
+					href: '#foo',
+					text: 'Go'
+				});
 
-			await page.getByTestId('target').click();
+				await page.getByTestId('target').click();
 
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
-			test.expect(new URL(page.url()).hash).toBe('#foo');
-		});
+				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
+				test.expect(new URL(page.url()).hash).toBe('#foo');
+			}
+		);
 
-		test('`javascript:` links', async ({page}) => {
-			const root = await createInitRouter('history', {
-				main: {
-					path: '/'
-				}
+		test(
+			'`javascript:` links',
+
+			async ({page}) => {
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
 				})(page, {
 					initialRoute: 'main'
 				});
 
-			await Component.createComponent(page, 'a', {
-				'data-testid': 'target',
-				href: 'javascript:void(globalThis.foo = "bar")',
-				text: 'Go'
-			});
+				await Component.createComponent(page, 'a', {
+					'data-testid': 'target',
+					href: 'javascript:void(globalThis.foo = "bar")',
+					text: 'Go'
+				});
 
-			await page.getByTestId('target').click();
+				await page.getByTestId('target').click();
 
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
-			await test.expect(root.evaluate(() => globalThis.foo)).toBeResolvedTo('bar');
-		});
+				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
+				await test.expect(root.evaluate(() => globalThis.foo)).toBeResolvedTo('bar');
+			}
+		);
 
-		test('`mailto:` links', async ({page}) => {
-			const root = await createInitRouter('history', {
-				main: {
-					path: '/'
-				}
+		test(
+			'`mailto:` links',
+
+			async ({page}) => {
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
 				})(page, {
 					initialRoute: 'main'
 				});
 
-			await Component.createComponent(page, 'a', {
-				'data-testid': 'target',
-				href: 'mailto:foo@bar.com',
-				text: 'Go'
-			});
+				await Component.createComponent(page, 'a', {
+					'data-testid': 'target',
+					href: 'mailto:foo@bar.com',
+					text: 'Go'
+				});
 
-			await page.getByTestId('target').click();
+				await page.getByTestId('target').click();
 
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
-		});
+				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
+			}
+		);
 
-		test('`tel:` links', async ({page}) => {
-			const root = await createInitRouter('history', {
-				main: {
-					path: '/'
-				}
+		test(
+			'`tel:` links',
+
+			async ({page}) => {
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
 				})(page, {
 					initialRoute: 'main'
 				});
 
-			await Component.createComponent(page, 'a', {
-				'data-testid': 'target',
-				href: 'tel:+71234567890',
-				text: 'Go'
-			});
+				await Component.createComponent(page, 'a', {
+					'data-testid': 'target',
+					href: 'tel:+71234567890',
+					text: 'Go'
+				});
 
-			await page.getByTestId('target').click();
+				await page.getByTestId('target').click();
 
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
-		});
+				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
+			}
+		);
 	});
 
 	test(
@@ -454,9 +475,9 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		test(
 			[
-				"calling the `preventRouterTransition` method on the event object should cancel the router's transition, " +
+				"calling the `preventRouterTransition` method on the event object should cancel the router's transition,",
 				"but not the browser's transition"
-			].join(''),
+			].join(' '),
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {

--- a/src/components/base/b-router/test/unit/links-on-page.ts
+++ b/src/components/base/b-router/test/unit/links-on-page.ts
@@ -40,7 +40,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'a link with the `data-router-prevent-transition` attribute should not be intercepted by the router and the browser',
+		[
+			'a click on a link with the `data-router-prevent-transition` attribute',
+			'should not be intercepted by the router and the browser'
+		].join(' '),
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -62,7 +65,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'clicks on links should not be intercepted if the router is initialized with the prop `interceptLinks` set to false',
+		'clicking on links should not be intercepted when the router is initialized with `interceptLinks` set to `false`',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -198,7 +201,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	});
 
 	test(
-		'query parameters in the link should be passed to the transition',
+		'the query parameters in the link should be passed to the transition',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -222,7 +225,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the `data-router-method` attribute should set the method of transition used by the router',
+		'the `data-router-method` attribute should set the transition method used by the router',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -257,7 +260,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the `data-router-go` attribute should set the parameters for the transition using the `router.go` method',
+		'the `data-router-go` attribute should set the transition parameters when using the `router.go` method',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -289,7 +292,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the `data-router-query` attribute should set the query parameters for the transition',
+		'the `data-router-query` attribute should set the query parameters for a transition',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -313,7 +316,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the query parameters passed through the URL link and the `data-router-query` attribute should be merged together',
+		[
+			'the query parameters passed in through the URL link and',
+			'the `data-router-query` attribute should be merged together'
+		].join(' '),
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -339,7 +345,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the `data-router-params` attribute should set the path parameters for the transition',
+		'the `data-router-params` attribute should set the path parameters for a transition',
 
 		async ({page}) => {
 			await createInitRouter('history', {
@@ -361,7 +367,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test(
-		'the `data-router-meta` attribute should set the meta parameters for the transition',
+		'the `data-router-meta` attribute should set the meta parameters for a transition',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -388,9 +394,9 @@ test.describe('<b-router> intercepting links on a page', () => {
 		}
 	);
 
-	test.describe('should emit the `hrefTransition` event when clicking a link', () => {
+	test.describe('the router should emit the `hrefTransition` event when a link is clicked', () => {
 		test(
-			'the event object should contain information about the link that was clicked',
+			'the event object should contain the information about the link that has been clicked',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {

--- a/src/components/base/b-router/test/unit/links-on-page.ts
+++ b/src/components/base/b-router/test/unit/links-on-page.ts
@@ -22,19 +22,19 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second',
+				href: '/',
 				text: 'Go'
 			});
 
 			await page.getByTestId('target').click();
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('second');
+			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
 		}
 	);
 
@@ -43,20 +43,20 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second',
+				href: '/',
 				text: 'Go',
 				'data-router-prevent-transition': 'true'
 			});
 
 			await page.getByTestId('target').click();
-			await test.expect(root.evaluate((ctx) => ctx.route?.name)).resolves.not.toBe('second');
+			await test.expect(root.evaluate((ctx) => ctx.route?.name)).resolves.not.toBe('main');
 		}
 	);
 
@@ -65,14 +65,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			}, {interceptLinks: false})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second',
+				href: '/',
 				text: 'Go'
 			});
 
@@ -85,12 +85,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 	);
 
 	test.describe('links that should not be intercepted by the router but should be intercepted by the browser', () => {
-		test('links with absolute URLs', async ({page}) => {
-			await createInitRouter('history', {
-				second: {
-					path: '/second'
-				}
-			})(page);
+				await createInitRouter('history')(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
@@ -106,12 +101,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 			const root = await createInitRouter('history', {
 				main: {
 					path: '/'
-				},
-
-				second: {
-					path: '/second'
 				}
-			})(page);
+				})(page, {
+					initialRoute: 'main'
+				});
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
@@ -119,7 +112,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				text: 'Go'
 			});
 
-			await root.evaluate((ctx) => ctx.router?.push('main'));
 			await page.getByTestId('target').click();
 
 			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
@@ -130,12 +122,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 			const root = await createInitRouter('history', {
 				main: {
 					path: '/'
-				},
-
-				second: {
-					path: '/second'
 				}
-			})(page);
+				})(page, {
+					initialRoute: 'main'
+				});
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
@@ -143,7 +133,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				text: 'Go'
 			});
 
-			await root.evaluate((ctx) => ctx.router?.push('main'));
 			await page.getByTestId('target').click();
 
 			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
@@ -154,12 +143,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 			const root = await createInitRouter('history', {
 				main: {
 					path: '/'
-				},
-
-				second: {
-					path: '/second'
 				}
-			})(page);
+				})(page, {
+					initialRoute: 'main'
+				});
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
@@ -167,7 +154,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				text: 'Go'
 			});
 
-			await root.evaluate((ctx) => ctx.router?.push('main'));
 			await page.getByTestId('target').click();
 
 			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
@@ -177,12 +163,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 			const root = await createInitRouter('history', {
 				main: {
 					path: '/'
-				},
-
-				second: {
-					path: '/second'
 				}
-			})(page);
+				})(page, {
+					initialRoute: 'main'
+				});
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
@@ -190,7 +174,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				text: 'Go'
 			});
 
-			await root.evaluate((ctx) => ctx.router?.push('main'));
 			await page.getByTestId('target').click();
 
 			await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
@@ -202,14 +185,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second?foo=bar&baz=bla',
+				href: '/?foo=bar&baz=bla',
 				text: 'Go'
 			});
 
@@ -233,6 +216,10 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 				second: {
 					path: '/second'
+				},
+
+				notFound: {
+					default: true
 				}
 			})(page);
 
@@ -290,14 +277,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second',
+				href: '/',
 				text: 'Go',
 				'data-router-query': JSON.stringify({foo: 'bar'})
 			});
@@ -314,14 +301,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second?a=1&b=2',
+				href: '/?a=1&b=2',
 				text: 'Go',
 				'data-router-query': JSON.stringify({a: 3, c: 4})
 			});
@@ -362,14 +349,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
-				second: {
-					path: '/second'
+				main: {
+					path: '/'
 				}
 			})(page);
 
 			await Component.createComponent(page, 'a', {
 				'data-testid': 'target',
-				href: '/second',
+				href: '/',
 				text: 'Go',
 				'data-router-meta': JSON.stringify({foo: 'bar'})
 			});
@@ -379,8 +366,8 @@ test.describe('<b-router> intercepting links on a page', () => {
 				foo: 'bar',
 				default: false,
 				external: false,
-				name: 'second',
-				path: '/second'
+				name: 'main',
+				path: '/'
 			});
 		}
 	);
@@ -444,14 +431,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
-					second: {
-						path: '/second'
+					main: {
+						path: '/'
 					}
 				})(page);
 
 				await Component.createComponent(page, 'a', {
 					'data-testid': 'target',
-					href: '/second',
+					href: '/',
 					text: 'Go'
 				});
 
@@ -460,7 +447,7 @@ test.describe('<b-router> intercepting links on a page', () => {
 				}));
 
 				await page.getByTestId('target').click();
-				await test.expect(root.evaluate((ctx) => ctx.route?.name)).resolves.not.toBe('second');
+				await test.expect(root.evaluate((ctx) => ctx.route?.name)).resolves.not.toBe('main');
 			}
 		);
 
@@ -472,14 +459,14 @@ test.describe('<b-router> intercepting links on a page', () => {
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
-					second: {
-						path: '/second'
+					main: {
+						path: '/'
 					}
 				}, {interceptLinks: false})(page);
 
 				await Component.createComponent(page, 'a', {
 					'data-testid': 'target',
-					href: '/second',
+					href: '/',
 					text: 'Go'
 				});
 

--- a/src/components/base/b-router/test/unit/links-on-page.ts
+++ b/src/components/base/b-router/test/unit/links-on-page.ts
@@ -78,7 +78,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 			});
 
 			await page.getByTestId('target').click();
-
 			await test.expect(
 				root.evaluate((ctx) => ctx.route?.name).catch((err) => err.message)
 			).toBeResolvedTo('jsHandle.evaluate: Execution context was destroyed, most likely because of a navigation');
@@ -122,7 +121,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				});
 
 				await page.getByTestId('target').click();
-
 				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
 				test.expect(new URL(page.url()).hash).toBe('#foo');
 			}
@@ -147,7 +145,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				});
 
 				await page.getByTestId('target').click();
-
 				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
 				await test.expect(root.evaluate(() => globalThis.foo)).toBeResolvedTo('bar');
 			}
@@ -172,7 +169,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				});
 
 				await page.getByTestId('target').click();
-
 				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
 			}
 		);
@@ -196,7 +192,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 				});
 
 				await page.getByTestId('target').click();
-
 				await test.expect(root.evaluate((ctx) => ctx.route?.name)).toBeResolvedTo('main');
 			}
 		);
@@ -219,7 +214,6 @@ test.describe('<b-router> intercepting links on a page', () => {
 			});
 
 			await page.getByTestId('target').click();
-
 			await test.expect(root.evaluate((ctx) => ctx.route?.query)).resolves.toEqual({
 				foo: 'bar',
 				baz: 'bla'

--- a/src/components/base/b-router/test/unit/links-on-page.ts
+++ b/src/components/base/b-router/test/unit/links-on-page.ts
@@ -12,6 +12,7 @@ import { Component } from 'tests/helpers';
 import { createInitRouter } from 'components/base/b-router/test/helpers';
 import type { HrefTransitionEvent } from 'components/base/b-router';
 
+// eslint-disable-next-line max-lines-per-function
 test.describe('<b-router> intercepting links on a page', () => {
 	test.beforeEach(async ({demoPage}) => {
 		await demoPage.goto();

--- a/src/components/base/b-router/test/unit/scroll-control.ts
+++ b/src/components/base/b-router/test/unit/scroll-control.ts
@@ -59,56 +59,68 @@ function generateSpecs(engineName: EngineName) {
 		});
 	});
 
-	test('should restore scroll position after the transition', async ({page}) => {
-		await scrollBy(page, [0, 500]);
+	test(
+		'should restore scroll position after the transition',
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
+		async ({page}) => {
+			await scrollBy(page, [0, 500]);
 
-		await root.evaluate(async ({router}) => {
-			// Reset scroll before the transition ends to check scroll restoration
-			router?.once('transition', () => {
-				// @ts-ignore "instance" behavior is available according to MDN docs
-				globalThis.scrollTo({top: 0, left: 0, behavior: 'instant'});
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
+
+			await root.evaluate(async ({router}) => {
+				// Reset scroll before the transition ends to check scroll restoration
+				router?.once('transition', () => {
+					// @ts-ignore "instance" behavior is available according to MDN docs
+					globalThis.scrollTo({top: 0, left: 0, behavior: 'instant'});
+				});
+
+				await router?.push(null, {query: {bla: 1}});
 			});
 
-			await router?.push(null, {query: {bla: 1}});
-		});
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 0]);
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 0]);
+			await root.evaluate(({router}) => router?.back());
+			await BOM.waitForIdleCallback(page);
 
-		await root.evaluate(({router}) => router?.back());
-		await BOM.waitForIdleCallback(page);
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
+		}
+	);
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
-	});
+	test(
+		'should reset scroll position on the hard change',
 
-	test('should reset scroll position on the hard change', async ({page}) => {
-		await scrollBy(page, [0, 500]);
+		async ({page}) => {
+			await scrollBy(page, [0, 500]);
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
 
-		await root.evaluate((ctx) => ctx.router?.push('second'));
-		await BOM.waitForIdleCallback(page);
+			await root.evaluate((ctx) => ctx.router?.push('second'));
+			await BOM.waitForIdleCallback(page);
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 0]);
-	});
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 0]);
+		}
+	);
 
-	test('should add scroll position to the current route meta', async ({page}) => {
-		await scrollBy(page, [0, 500]);
+	test(
+		'should add scroll position to the current route meta',
 
-		await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
+		async ({page}) => {
+			await scrollBy(page, [0, 500]);
 
-		await root.evaluate(({router}) => router?.push(null, {query: {bla: 1}}));
-		await root.evaluate(({router}) => router?.back());
+			await test.expect(getScrollPosition(page)).resolves.toEqual([0, 500]);
 
-		// Check that router.engine route has scroll
-		await test.expect(root.evaluate(({router}) => router?.unsafe.engine.route?.meta.scroll))
-			.resolves.toEqual({x: 0, y: 500});
+			await root.evaluate(({router}) => router?.push(null, {query: {bla: 1}}));
+			await root.evaluate(({router}) => router?.back());
 
-		// Check that root component route has scroll
-		await test.expect(root.evaluate(({route}) => route?.meta.scroll))
-			.resolves.toEqual({x: 0, y: 500});
-	});
+			// Check that router.engine route has scroll
+			await test.expect(root.evaluate(({router}) => router?.unsafe.engine.route?.meta.scroll))
+				.resolves.toEqual({x: 0, y: 500});
+
+			// Check that root component route has scroll
+			await test.expect(root.evaluate(({route}) => route?.meta.scroll))
+				.resolves.toEqual({x: 0, y: 500});
+		}
+	);
 
 	/**
 	 * Returns the scroll position: [x, y]

--- a/src/components/base/b-router/test/unit/scroll-control.ts
+++ b/src/components/base/b-router/test/unit/scroll-control.ts
@@ -70,7 +70,7 @@ function generateSpecs(engineName: EngineName) {
 			await root.evaluate(async ({router}) => {
 				// Reset scroll before the transition ends to check scroll restoration
 				router?.once('transition', () => {
-					// @ts-ignore "instance" behavior is available according to MDN docs
+					// @ts-ignore "instant" behavior is available according to MDN docs
 					globalThis.scrollTo({top: 0, left: 0, behavior: 'instant'});
 				});
 

--- a/src/components/base/b-router/test/unit/scroll-control.ts
+++ b/src/components/base/b-router/test/unit/scroll-control.ts
@@ -60,7 +60,7 @@ function generateSpecs(engineName: EngineName) {
 	});
 
 	test(
-		'should restore scroll position after the transition',
+		'the router should restore the scroll position after a transition',
 
 		async ({page}) => {
 			await scrollBy(page, [0, 500]);
@@ -87,7 +87,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'should reset scroll position on the hard change',
+		'the router should reset the scroll position on the hard change',
 
 		async ({page}) => {
 			await scrollBy(page, [0, 500]);
@@ -102,7 +102,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'should add scroll position to the current route meta',
+		'the router should add the scroll position to the current route meta',
 
 		async ({page}) => {
 			await scrollBy(page, [0, 500]);

--- a/src/components/base/b-router/test/unit/scroll-control.ts
+++ b/src/components/base/b-router/test/unit/scroll-control.ts
@@ -37,12 +37,22 @@ test.describe('<b-router> scroll control', () => {
  */
 function generateSpecs(engineName: EngineName) {
 	/* eslint-disable playwright/require-top-level-describe */
-	const initRouter = createInitRouter(engineName);
+	const initRouter = createInitRouter(engineName, {
+		main: {
+			path: '/'
+		},
+
+		second: {
+			path: '/second'
+		}
+	});
 
 	let root: JSHandle<iStaticPage>;
 
 	test.beforeEach(async ({page}) => {
-		root = await initRouter(page);
+		root = await initRouter(page, {
+			initialRoute: 'main'
+		});
 
 		await page.addStyleTag({
 			content: '#root-component {height: 3000px;}'

--- a/src/components/base/b-router/test/unit/simple.ts
+++ b/src/components/base/b-router/test/unit/simple.ts
@@ -50,7 +50,7 @@ test.describe('<b-router> simple use-cases', () => {
 
 			test.describe('`replace`', () => {
 				test(
-					'should switch page using a non-normalized path',
+					'should switch the page and not change the length of the history',
 
 					async () => {
 						await test.expect(root.evaluate(async (ctx) => {
@@ -73,7 +73,7 @@ test.describe('<b-router> simple use-cases', () => {
 				);
 
 				test(
-					'should not switch page and query should be updated when `null` and opts are passed',
+					'should merge the new query parameters with the existing ones if the route name is set to `null`',
 
 					async () => {
 						await test.expect(root.evaluate(async (ctx) => {
@@ -132,7 +132,7 @@ test.describe('<b-router> simple use-cases', () => {
 
 			test.describe('`replace`', () => {
 				test(
-					'should switch page using a non-normalized path',
+					'should switch the page and not change the length of the history',
 
 					async ({page}) => {
 						const root = await initRouter(page);
@@ -158,7 +158,7 @@ test.describe('<b-router> simple use-cases', () => {
 				);
 
 				test(
-					'should not switch page and query should be updated when `null` and opts are passed',
+					'should merge the new query parameters with the existing ones if the route name is set to `null`',
 
 					async ({page}) => {
 						const root = await initRouter(page);
@@ -229,7 +229,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'root component should have the `root` property in the meta params',
+		'the root component should have a `root` property in the meta params',
 
 		async () => {
 			test.expect(await root.evaluate((ctx) => ctx.unsafe.meta.params.root)).toBe(true);
@@ -237,7 +237,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'root\'s component `router` should be a `b-router`',
+		'the root\'s `router` field should be a `b-router` component',
 
 		async () => {
 			test.expect(await root.evaluate(({router}) => router?.componentName)).toBe('b-router');
@@ -246,7 +246,7 @@ function generateSpecs(engineName: EngineName) {
 
 	test.describe('`push`', () => {
 		test(
-			'should switch page using a route identifier',
+			'should switch the page using a route identifier',
 
 			async () => {
 				await assertPathTransitionsTo(root, 'second', 'Second page');
@@ -254,7 +254,7 @@ function generateSpecs(engineName: EngineName) {
 		);
 
 		test(
-			'should switch page using a path',
+			'should switch the page using a path',
 
 			async () => {
 				await assertPathTransitionsTo(root, '/', 'Main page');
@@ -263,7 +263,7 @@ function generateSpecs(engineName: EngineName) {
 	});
 
 	test(
-		'`activePage` property should return identifier of the active route',
+		'`activePage` property should return the identifier of the active route',
 
 		async () => {
 			await test.expect(root.evaluate(async (ctx) => {
@@ -280,7 +280,7 @@ function generateSpecs(engineName: EngineName) {
 
 	test.describe('`updateRoutes`', () => {
 		test(
-			'should switch page to a new default route',
+			'should switch the page to a new default route',
 
 			async () => {
 				await test.expect(root.evaluate(async (ctx) => {
@@ -317,7 +317,7 @@ function generateSpecs(engineName: EngineName) {
 		);
 
 		test(
-			'should update `basePath` and switch page to the specified `activeRoute`',
+			'should update `basePath` and switch the page to the specified `activeRoute`',
 
 			async () => {
 				await test.expect(root.evaluate(async (ctx) => {
@@ -362,7 +362,7 @@ function generateSpecs(engineName: EngineName) {
 	});
 
 	test(
-		'`getRoutePath` should return URL of the route with the specified `query`',
+		'`getRoutePath` should return an URL of the route with a specified `query`',
 
 		async () => {
 			await test.expect(root.evaluate(({router}) => router!.getRoutePath('second', {query: {bla: 1}})))
@@ -374,7 +374,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'`getRoute` should return route descriptor using a route identifier or path',
+		'`getRoute` should return the route descriptor using either a route identifier or a path',
 
 		async () => {
 			const pageMeta = {

--- a/src/components/base/b-router/test/unit/simple.ts
+++ b/src/components/base/b-router/test/unit/simple.ts
@@ -49,51 +49,59 @@ test.describe('<b-router> simple use-cases', () => {
 			});
 
 			test.describe('`replace`', () => {
-				test('should switch page using a non-normalized path', async () => {
-					await test.expect(root.evaluate(async (ctx) => {
-						const
-							historyLength = history.length,
-							res: Dictionary = {};
+				test(
+					'should switch page using a non-normalized path',
+
+					async () => {
+						await test.expect(root.evaluate(async (ctx) => {
+							const
+								historyLength = history.length,
+								res: Dictionary = {};
 
 							await ctx.router!.replace('second');
 
-						res.content = ctx.route!.meta.content;
-						res.lengthDoesntChange = historyLength === history.length;
+							res.content = ctx.route!.meta.content;
+							res.lengthDoesntChange = historyLength === history.length;
 
-						return res;
+							return res;
 
-					})).resolves.toEqual({
-						content: 'Second page',
-						lengthDoesntChange: true
-					});
-				});
+						})).resolves.toEqual({
+							content: 'Second page',
+							lengthDoesntChange: true
+						});
+					}
+				);
 
-				test('should not switch page and query should be updated when `null` and opts are passed', async () => {
-					await test.expect(root.evaluate(async (ctx) => {
-						const
-							{router} = ctx;
+				test(
+					'should not switch page and query should be updated when `null` and opts are passed',
 
-						await router!.replace('/');
+					async () => {
+						await test.expect(root.evaluate(async (ctx) => {
+							const
+								{router} = ctx;
 
-						const
-							historyLength = history.length,
-							res: Dictionary = {};
+							await router!.replace('/');
 
-						await router!.replace('second');
-						await router!.replace(null, {query: {bla: 1}});
+							const
+								historyLength = history.length,
+								res: Dictionary = {};
 
-						res.content = ctx.route!.meta.content;
-						res.query = location.search;
-						res.lengthDoesntChange = historyLength === history.length;
+							await router!.replace('second');
+							await router!.replace(null, {query: {bla: 1}});
 
-						return res;
+							res.content = ctx.route!.meta.content;
+							res.query = location.search;
+							res.lengthDoesntChange = historyLength === history.length;
 
-					})).resolves.toEqual({
-						query: '?bla=1',
-						content: 'Second page',
-						lengthDoesntChange: true
-					});
-				});
+							return res;
+
+						})).resolves.toEqual({
+							query: '?bla=1',
+							content: 'Second page',
+							lengthDoesntChange: true
+						});
+					}
+				);
 			});
 		});
 	});
@@ -118,62 +126,74 @@ test.describe('<b-router> simple use-cases', () => {
 				}
 			});
 
-			test('the `route` property should be `null` when `initialRoute` is not set', async ({page}) => {
-				const root = await initRouter(page, {initialRoute: null});
-				await test.expect(root.evaluate(({route}) => route == null)).resolves.toBeTruthy();
-			});
+			test(
+				'the `route` property should be `null` when `initialRoute` is not set',
+
+				async ({page}) => {
+					const root = await initRouter(page, {initialRoute: null});
+					await test.expect(root.evaluate(({route}) => route == null)).resolves.toBeTruthy();
+				}
+			);
 
 			test.describe('`replace`', () => {
-				test('should switch page using a non-normalized path', async ({page}) => {
-					const root = await initRouter(page);
+				test(
+					'should switch page using a non-normalized path',
 
-					await test.expect(root.evaluate(async (ctx) => {
-						const
-							{router} = ctx,
-							historyLength = router!.unsafe.engine.history.length,
-							res: Dictionary = {};
+					async ({page}) => {
+						const root = await initRouter(page);
+
+						await test.expect(root.evaluate(async (ctx) => {
+							const
+								{router} = ctx,
+								historyLength = router!.unsafe.engine.history.length,
+								res: Dictionary = {};
 
 							await router!.replace('second');
 
-						res.content = ctx.route!.meta.content;
-						res.lengthDoesntChange = historyLength === router!.unsafe.engine.history.length;
+							res.content = ctx.route!.meta.content;
+							res.lengthDoesntChange = historyLength === router!.unsafe.engine.history.length;
 
-						return res;
+							return res;
 
-					})).resolves.toEqual({
-						content: 'Second page',
-						lengthDoesntChange: true
-					});
-				});
+						})).resolves.toEqual({
+							content: 'Second page',
+							lengthDoesntChange: true
+						});
+					}
+				);
 
-				test('should not switch page and query should be updated when `null` and opts are passed', async ({page}) => {
-					const root = await initRouter(page);
+				test(
+					'should not switch page and query should be updated when `null` and opts are passed',
 
-					await test.expect(root.evaluate(async (ctx) => {
-						const
-							{router} = ctx;
+					async ({page}) => {
+						const root = await initRouter(page);
 
-						await router!.replace('/');
+						await test.expect(root.evaluate(async (ctx) => {
+							const
+								{router} = ctx;
 
-						const
-							historyLength = router!.unsafe.engine.history.length,
-							res: Dictionary = {};
+							await router!.replace('/');
 
-						await router!.replace('second');
-						await router!.replace(null, {query: {bla: 1}});
+							const
+								historyLength = router!.unsafe.engine.history.length,
+								res: Dictionary = {};
 
-						res.content = ctx.route!.meta.content;
-						res.query = ctx.route!.query;
-						res.lengthDoesntChange = historyLength === router!.unsafe.engine.history.length;
+							await router!.replace('second');
+							await router!.replace(null, {query: {bla: 1}});
 
-						return res;
+							res.content = ctx.route!.meta.content;
+							res.query = ctx.route!.query;
+							res.lengthDoesntChange = historyLength === router!.unsafe.engine.history.length;
 
-					})).resolves.toEqual({
-						content: 'Second page',
-						query: {bla: 1},
-						lengthDoesntChange: true
-					});
-				});
+							return res;
+
+						})).resolves.toEqual({
+							content: 'Second page',
+							query: {bla: 1},
+							lengthDoesntChange: true
+						});
+					}
+				);
 			});
 		});
 	});
@@ -207,146 +227,186 @@ function generateSpecs(engineName: EngineName) {
 		root = await initRouter(page);
 	});
 
-	test('the `route` property should be set on the root component', async () => {
-		await test.expect(root.evaluate(({route}) => route != null)).resolves.toBeTruthy();
-	});
+	test(
+		'the `route` property should be set on the root component',
 
-	test('root component should have the `root` property in the meta params', async () => {
-		test.expect(await root.evaluate((ctx) => ctx.unsafe.meta.params.root)).toBe(true);
-	});
+		async () => {
+			await test.expect(root.evaluate(({route}) => route != null)).resolves.toBeTruthy();
+		}
+	);
 
-	test('root\'s component `router` should be a `b-router`', async () => {
-		test.expect(await root.evaluate(({router}) => router?.componentName)).toBe('b-router');
-	});
+	test(
+		'root component should have the `root` property in the meta params',
+
+		async () => {
+			test.expect(await root.evaluate((ctx) => ctx.unsafe.meta.params.root)).toBe(true);
+		}
+	);
+
+	test(
+		'root\'s component `router` should be a `b-router`',
+
+		async () => {
+			test.expect(await root.evaluate(({router}) => router?.componentName)).toBe('b-router');
+		}
+	);
 
 	test.describe('`push`', () => {
-		test('should switch page using a route identifier', async () => {
+		test(
+			'should switch page using a route identifier',
+
+			async () => {
+				await test.expect(root.evaluate(async (ctx) => {
+					await ctx.router!.push('second');
+					return ctx.route!.meta.content;
+				})).toBeResolvedTo('Second page');
+			}
+		);
+
+		test(
+			'should switch page using a path',
+
+			async () => {
+				await test.expect(root.evaluate(async (ctx) => {
+					await ctx.router!.push('/');
+					return ctx.route!.meta.content;
+				})).toBeResolvedTo('Main page');
+			}
+		);
+	});
+
+	test(
+		'`activePage` property should return identifier of the active route',
+
+		async () => {
 			await test.expect(root.evaluate(async (ctx) => {
 				await ctx.router!.push('second');
-				return ctx.route!.meta.content;
-			})).toBeResolvedTo('Second page');
-		});
+				return ctx.activePage;
+			})).toBeResolvedTo('second');
 
-		test('should switch page using a path', async () => {
 			await test.expect(root.evaluate(async (ctx) => {
-				await ctx.router!.push('/');
-				return ctx.route!.meta.content;
-			})).toBeResolvedTo('Main page');
-		});
-	});
-
-	test('`activePage` property should return identifier of the active route', async () => {
-		await test.expect(root.evaluate(async (ctx) => {
-			await ctx.router!.push('second');
-			return ctx.activePage;
-		})).toBeResolvedTo('second');
-
-		await test.expect(root.evaluate(async (ctx) => {
-			await ctx.router!.push('main');
-			return ctx.activePage;
-		})).toBeResolvedTo('main');
-	});
+				await ctx.router!.push('main');
+				return ctx.activePage;
+			})).toBeResolvedTo('main');
+		}
+	);
 
 	test.describe('`updateRoutes`', () => {
-		test('should switch page to a new default route', async () => {
-			await test.expect(root.evaluate(async (ctx) => {
-				const
-					{router} = ctx;
+		test(
+			'should switch page to a new default route',
 
-				const
-					res: Dictionary = {},
-					oldRoutes = ctx.router!.routes;
+			async () => {
+				await test.expect(root.evaluate(async (ctx) => {
+					const
+						{router} = ctx;
 
-				await router!.updateRoutes({
-					main: {
-						path: '/',
-						default: true,
-						content: 'Dynamic main page'
-					}
+					const
+						res: Dictionary = {},
+						oldRoutes = ctx.router!.routes;
+
+					await router!.updateRoutes({
+						main: {
+							path: '/',
+							default: true,
+							content: 'Dynamic main page'
+						}
+					});
+
+					res.dynamicPage = ctx.route!.meta.content;
+
+					router!.routes = oldRoutes;
+					router!.unsafe.routeStore = undefined;
+
+					await router!.unsafe.initRoute('main');
+					res.restoredPage = ctx.route!.meta.content;
+
+					return res;
+
+				})).resolves.toEqual({
+					dynamicPage: 'Dynamic main page',
+					restoredPage: 'Main page'
 				});
+			}
+		);
 
-				res.dynamicPage = ctx.route!.meta.content;
+		test(
+			'should update `basePath` and switch page to the specified `activeRoute`',
 
-				router!.routes = oldRoutes;
-				router!.unsafe.routeStore = undefined;
+			async () => {
+				await test.expect(root.evaluate(async (ctx) => {
+					const
+						{router} = ctx;
 
-				await router!.unsafe.initRoute('main');
-				res.restoredPage = ctx.route!.meta.content;
+					const
+						res: Dictionary = {},
+						oldRoutes = ctx.router!.routes;
 
-				return res;
+					await router!.updateRoutes('/demo', '/demo/second', {
+						main: {
+							path: '/',
+							default: true,
+							content: 'Dynamic main page'
+						},
 
-			})).resolves.toEqual({
-				dynamicPage: 'Dynamic main page',
-				restoredPage: 'Main page'
-			});
-		});
+						second: {
+							path: '/second',
+							default: true,
+							content: 'Dynamic second page'
+						}
+					});
 
-		test('should update `basePath` and switch page to the specified `activeRoute`', async () => {
-			await test.expect(root.evaluate(async (ctx) => {
-				const
-					{router} = ctx;
+					res.dynamicPage = ctx.route!.meta.content;
 
-				const
-					res: Dictionary = {},
-					oldRoutes = ctx.router!.routes;
+					router!.basePath = '/';
+					router!.routes = oldRoutes;
+					router!.unsafe.routeStore = undefined;
 
-				await router!.updateRoutes('/demo', '/demo/second', {
-					main: {
-						path: '/',
-						default: true,
-						content: 'Dynamic main page'
-					},
+					await router!.unsafe.initRoute('/');
+					res.restoredPage = ctx.route!.meta.content;
 
-					second: {
-						path: '/second',
-						default: true,
-						content: 'Dynamic second page'
-					}
+					return res;
+
+				})).resolves.toEqual({
+					dynamicPage: 'Dynamic second page',
+					restoredPage: 'Main page'
 				});
-
-				res.dynamicPage = ctx.route!.meta.content;
-
-				router!.basePath = '/';
-				router!.routes = oldRoutes;
-				router!.unsafe.routeStore = undefined;
-
-				await router!.unsafe.initRoute('/');
-				res.restoredPage = ctx.route!.meta.content;
-
-				return res;
-
-			})).resolves.toEqual({
-				dynamicPage: 'Dynamic second page',
-				restoredPage: 'Main page'
-			});
-		});
+			}
+		);
 	});
 
-	test('`getRoutePath` should return URL of the route with the specified `query`', async () => {
-		test.expect(await root.evaluate(({router}) => router!.getRoutePath('second', {query: {bla: 1}})))
+	test(
+		'`getRoutePath` should return URL of the route with the specified `query`',
+
+		async () => {
+			test.expect(await root.evaluate(({router}) => router!.getRoutePath('second', {query: {bla: 1}})))
 				.toBe('/second?bla=1');
 
-		test.expect(await root.evaluate(({router}) => router!.getRoutePath('/', {query: {bla: 1}})))
-			.toBe('/?bla=1');
-	});
+			test.expect(await root.evaluate(({router}) => router!.getRoutePath('/', {query: {bla: 1}})))
+				.toBe('/?bla=1');
+		}
+	);
 
-	test('`getRoute` should return route descriptor using a route identifier or path', async () => {
-		const pageMeta = {
-			name: 'main',
-			path: '/',
-			default: false,
-			external: false,
-			content: 'Main page'
-		};
+	test(
+		'`getRoute` should return route descriptor using a route identifier or path',
 
-		await test.expect(root.evaluate(({router}) => {
-			const route = router!.getRoute('main');
-			return route!.meta;
-		})).resolves.toEqual(pageMeta);
+		async () => {
+			const pageMeta = {
+				name: 'main',
+				path: '/',
+				default: false,
+				external: false,
+				content: 'Main page'
+			};
 
-		await test.expect(root.evaluate(({router}) => {
-			const route = router!.getRoute('/');
-			return route!.meta;
-		})).resolves.toEqual(pageMeta);
-	});
+			await test.expect(root.evaluate(({router}) => {
+				const route = router!.getRoute('main');
+				return route!.meta;
+			})).resolves.toEqual(pageMeta);
+
+			await test.expect(root.evaluate(({router}) => {
+				const route = router!.getRoute('/');
+				return route!.meta;
+			})).resolves.toEqual(pageMeta);
+		}
+	);
 }

--- a/src/components/base/b-router/test/unit/simple.ts
+++ b/src/components/base/b-router/test/unit/simple.ts
@@ -28,12 +28,24 @@ test.describe('<b-router> simple use-cases', () => {
 
 		// Specific tests
 		test.describe('-', () => {
-			const initRouter = createInitRouter('history');
+			const initRouter = createInitRouter('history', {
+				main: {
+					path: '/',
+					content: 'Main page'
+				},
+
+				second: {
+					path: '/second',
+					content: 'Second page'
+				}
+			});
 
 			let root: JSHandle<iStaticPage>;
 
 			test.beforeEach(async ({page}) => {
-				root = await initRouter(page);
+				root = await initRouter(page, {
+					initialRoute: 'main'
+				});
 			});
 
 			test.describe('`replace`', () => {
@@ -43,7 +55,7 @@ test.describe('<b-router> simple use-cases', () => {
 							historyLength = history.length,
 							res: Dictionary = {};
 
-						await ctx.router!.replace('second-page');
+							await ctx.router!.replace('second');
 
 						res.content = ctx.route!.meta.content;
 						res.lengthDoesntChange = historyLength === history.length;
@@ -94,7 +106,17 @@ test.describe('<b-router> simple use-cases', () => {
 
 		// Specific tests
 		test.describe('-', () => {
-			const initRouter = createInitRouter('in-memory');
+			const initRouter = createInitRouter('in-memory', {
+				main: {
+					path: '/',
+					content: 'Main page'
+				},
+
+				second: {
+					path: '/second',
+					content: 'Second page'
+				}
+			});
 
 			test('the `route` property should be `null` when `initialRoute` is not set', async ({page}) => {
 				const root = await initRouter(page, {initialRoute: null});
@@ -111,7 +133,7 @@ test.describe('<b-router> simple use-cases', () => {
 							historyLength = router!.unsafe.engine.history.length,
 							res: Dictionary = {};
 
-						await router!.replace('second-page');
+							await router!.replace('second');
 
 						res.content = ctx.route!.meta.content;
 						res.lengthDoesntChange = historyLength === router!.unsafe.engine.history.length;
@@ -163,7 +185,21 @@ test.describe('<b-router> simple use-cases', () => {
  */
 function generateSpecs(engineName: EngineName) {
 	/* eslint-disable playwright/require-top-level-describe */
-	const initRouter = createInitRouter(engineName);
+	const initRouter = createInitRouter(engineName, {
+		main: {
+			path: '/',
+			content: 'Main page'
+		},
+
+		second: {
+			path: '/second',
+			content: 'Second page'
+		},
+
+		notFound: {
+			default: true
+		}
+	});
 
 	let root: JSHandle<iStaticPage>;
 
@@ -288,7 +324,7 @@ function generateSpecs(engineName: EngineName) {
 
 	test('`getRoutePath` should return URL of the route with the specified `query`', async () => {
 		test.expect(await root.evaluate(({router}) => router!.getRoutePath('second', {query: {bla: 1}})))
-			.toBe('/second-page?bla=1');
+				.toBe('/second?bla=1');
 
 		test.expect(await root.evaluate(({router}) => router!.getRoutePath('/', {query: {bla: 1}})))
 			.toBe('/?bla=1');

--- a/src/components/base/b-router/test/unit/transition/events.ts
+++ b/src/components/base/b-router/test/unit/transition/events.ts
@@ -257,8 +257,12 @@ test.describe('<b-router> standard transition events', () => {
 
 				second: {
 					path: '/second'
+				},
+
+				third: {
+					path: '/third'
 				}
-			})(page);
+			})(page, {initialRoute: 'main'});
 
 			const log = await root.evaluate(async (ctx) => {
 				const
@@ -277,10 +281,10 @@ test.describe('<b-router> standard transition events', () => {
 					}
 				});
 
-				await router.push('main', {query: {foo: 1}});
+				await router.push('second', {query: {foo: 1}});
 				res.pathChanges?.push(getPath());
 
-				await router.push('second', {query: {bar: 2}});
+				await router.push('third', {query: {bar: 2}});
 				await router.push(null, {query: {bar: 3}});
 				await router.push(null, {query: {bar: 4}});
 				res.pathChanges?.push(getPath());
@@ -296,7 +300,7 @@ test.describe('<b-router> standard transition events', () => {
 			});
 
 			test.expect(log).toEqual({
-				pathChanges: ['/?foo=1', '/second?bar=4', '/'],
+				pathChanges: ['/second?foo=1', '/third?bar=4', '/'],
 				onHardChange: [['initial', {}], {foo: 1}, {bar: 2}, {}]
 			});
 		}
@@ -624,7 +628,7 @@ test.describe('<b-router> standard transition events', () => {
 				second: {
 					path: '/second'
 				}
-			})(page);
+			})(page, {initialRoute: 'main'});
 
 			const log = await root.evaluate(async (ctx) => {
 				const

--- a/src/components/base/b-router/test/unit/transition/events.ts
+++ b/src/components/base/b-router/test/unit/transition/events.ts
@@ -382,9 +382,9 @@ test.describe('<b-router> standard transition events', () => {
 
 	test(
 		[
-			'The change event should be emitted whenever there is any transition in which any parameters have changed ',
+			'The change event should be emitted whenever there is any transition in which any parameters have changed',
 			'or the length of the history has changed'
-		].join(''),
+		].join(' '),
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -615,9 +615,9 @@ test.describe('<b-router> standard transition events', () => {
 
 	test(
 		[
-			'the order of event triggering should be as follows: ',
+			'the order of event triggering should be as follows:',
 			'`beforeChange`, `softChange/hardChange`, `change`, `transition`, `$root.transition`'
-		].join(''),
+		].join(' '),
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {

--- a/src/components/base/b-router/test/unit/transition/events.ts
+++ b/src/components/base/b-router/test/unit/transition/events.ts
@@ -69,7 +69,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'changes made to the route parameters during the handling of the `beforeChange` event should affect the transition',
+		'changes made to the route parameters during handling of the `beforeChange` event should affect the transition',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -99,7 +99,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'the `softChange` event should only be fired in transitions where only query parameters have changed',
+		'the `softChange` event should be fired only in those transitions where the query parameters have been changed',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -175,7 +175,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'the `softChange` event should be fired when navigating through history',
+		'the `softChange` event should fire when navigating through history',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -247,7 +247,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'the `hardChange` event should be fired only in those transitions where route IDs have changed',
+		'the `hardChange` event should only be fired in those transitions where the route ID has changed',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -307,7 +307,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'the `hardChange` event should be fired when navigating through history',
+		'the `hardChange` event should fire when navigating through history',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -382,8 +382,8 @@ test.describe('<b-router> standard transition events', () => {
 
 	test(
 		[
-			'The change event should be emitted whenever there is any transition in which any parameters have changed',
-			'or the length of the history has changed'
+			'the `change` event should be fired whenever there is a transition that changes any parameters',
+			'or when the history length changes'
 		].join(' '),
 
 		async ({page}) => {
@@ -463,7 +463,7 @@ test.describe('<b-router> standard transition events', () => {
 	);
 
 	test(
-		'the `change` event should be fired when navigating through history',
+		'the `change` event should fire when navigating through history',
 
 		async ({page}) => {
 			const root = await createInitRouter('history', {
@@ -615,7 +615,7 @@ test.describe('<b-router> standard transition events', () => {
 
 	test(
 		[
-			'the order of event triggering should be as follows:',
+			'the order of triggering events should be as follows:',
 			'`beforeChange`, `softChange/hardChange`, `change`, `transition`, `$root.transition`'
 		].join(' '),
 

--- a/src/components/base/b-router/test/unit/transition/parameters.ts
+++ b/src/components/base/b-router/test/unit/transition/parameters.ts
@@ -17,7 +17,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		await demoPage.goto();
 	});
 
-	test.describe('transition through paths that include interpolation of values from transition parameters', () => {
+	test.describe('transition through paths, including interpolation of values from transition parameters', () => {
 		test(
 			'parameters from `params` should be passed as values into the transition path where `:paramName` constructs are located',
 
@@ -41,7 +41,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'if path parameters are not passed along with the transition, the transition to this path will not be made',
+			'if the path parameters are not included in the transition, the transition will not take place',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -59,7 +59,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'if a parameter in the path has a `?` symbol at the end during interpolation, it should be optional',
+			'if a parameter in the path ends with a `?` symbol, it should be optional',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -77,7 +77,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'correctly parses parameters in href with query parameters',
+			'the router should be able to parse parameters from an href with query parameters',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -93,7 +93,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'by default, parameters for path interpolation can be taken not only from params, but also from query',
+			'by default, path interpolation parameters can be taken not only from params, but also from the query',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -110,7 +110,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			"if the route's `paramsFromQuery` option is set to false, the parameters for interpolation should only be taken from `params`",
+			'if the route\'s `paramsFromQuery` option is set to `false`, interpolation parameters should be taken only from the `params`',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -128,7 +128,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'support for aliases for interpolation parameters',
+			'the router should support aliases for interpolation parameters',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -163,7 +163,7 @@ test.describe('<b-router> passing transition parameters', () => {
 
 	test.describe('passing parameters to a route with the same name as the current one', () => {
 		test(
-			'if the route name is set to null, then the new parameters should be merged with the old ones',
+			'if the route name is set to `null`, new parameters should be merged with the existing ones',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {
@@ -188,8 +188,8 @@ test.describe('<b-router> passing transition parameters', () => {
 
 		test(
 			[
-				'if the route name is explicitly set as a string,',
-				'then the new parameters should completely replace the old ones'
+				'if the route name is explicitly specified as a string,',
+				'then the new parameters should entirely replace the existing ones'
 			].join(' '),
 
 			async ({page}) => {
@@ -218,7 +218,7 @@ test.describe('<b-router> passing transition parameters', () => {
 		);
 
 		test(
-			'parameters should never be merged if we are navigating through the history',
+			'parameters should not merge if navigation occurs through history',
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {

--- a/src/components/base/b-router/test/unit/transition/parameters.ts
+++ b/src/components/base/b-router/test/unit/transition/parameters.ts
@@ -100,6 +100,7 @@ test.describe('<b-router> passing transition parameters', () => {
 
 		test(
 			'correctly parses parameters in href with query parameters',
+
 			async ({page}) => {
 				const root = await createInitRouter('history', {
 					user: {
@@ -151,53 +152,57 @@ test.describe('<b-router> passing transition parameters', () => {
 			}
 		);
 
-		test('support for aliases for interpolation parameters', async ({page}) => {
-			const root = await createInitRouter('history', {
-				tpl: {
-					path: '/tpl/:param1/:param2?',
-					pathOpts: {
-						aliases: {
-							param1: ['_param1', 'Param1'],
-							param2: ['Param2']
+		test(
+			'support for aliases for interpolation parameters',
+
+			async ({page}) => {
+				const root = await createInitRouter('history', {
+					tpl: {
+						path: '/tpl/:param1/:param2?',
+						pathOpts: {
+							aliases: {
+								param1: ['_param1', 'Param1'],
+								param2: ['Param2']
+							}
 						}
 					}
-				}
-			})(page);
+				})(page);
 
-			await test.expect(root.evaluate(async (ctx) => {
-				const
-					router = ctx.router!,
-					transitions: Dictionary = {};
+				await test.expect(root.evaluate(async (ctx) => {
+					const
+						router = ctx.router!,
+						transitions: Dictionary = {};
 
-				await router.push('tpl', {params: {param1: 'foo'}});
-				transitions.path1 = getPath();
+					await router.push('tpl', {params: {param1: 'foo'}});
+					transitions.path1 = getPath();
 
-				await router.push('tpl', {params: {param1: 'foo', _param1: 'bar'}});
-				transitions.path2 = getPath();
+					await router.push('tpl', {params: {param1: 'foo', _param1: 'bar'}});
+					transitions.path2 = getPath();
 
-				await router.push('tpl', {params: {Param1: 'foo'}});
-				transitions.path3 = getPath();
+					await router.push('tpl', {params: {Param1: 'foo'}});
+					transitions.path3 = getPath();
 
-				await router.push('tpl', {params: {Param1: 'bar', _param1: 'foo'}});
-				transitions.path4 = getPath();
+					await router.push('tpl', {params: {Param1: 'bar', _param1: 'foo'}});
+					transitions.path4 = getPath();
 
-				await router.push('tpl', {params: {_param1: 'foo'}, query: {Param1: 'bla', Param2: 'bar'}});
-				transitions.path5 = getPath();
+					await router.push('tpl', {params: {_param1: 'foo'}, query: {Param1: 'bla', Param2: 'bar'}});
+					transitions.path5 = getPath();
 
-				return transitions;
+					return transitions;
 
-				function getPath() {
-					return location.pathname + location.search;
-				}
+					function getPath() {
+						return location.pathname + location.search;
+					}
 
-			})).resolves.toEqual({
-				path1: '/tpl/foo',
-				path2: '/tpl/foo',
-				path3: '/tpl/foo',
-				path4: '/tpl/foo',
-				path5: '/tpl/foo/bar?Param1=bla'
-			});
-		});
+				})).resolves.toEqual({
+					path1: '/tpl/foo',
+					path2: '/tpl/foo',
+					path3: '/tpl/foo',
+					path4: '/tpl/foo',
+					path5: '/tpl/foo/bar?Param1=bla'
+				});
+			}
+		);
 	});
 
 	test.describe('passing parameters to a route with the same name as the current one', () => {
@@ -245,9 +250,9 @@ test.describe('<b-router> passing transition parameters', () => {
 
 		test(
 			[
-				'if the route name is explicitly set as a string, ',
+				'if the route name is explicitly set as a string,',
 				'then the new parameters should completely replace the old ones'
-			].join(''),
+			].join(' '),
 
 			async ({page}) => {
 				const root = await createInitRouter('history', {

--- a/src/components/base/b-router/test/unit/transition/parameters.ts
+++ b/src/components/base/b-router/test/unit/transition/parameters.ts
@@ -205,7 +205,11 @@ test.describe('<b-router> passing transition parameters', () => {
 			'if the route name is set to null, then the new parameters should be merged with the old ones',
 
 			async ({page}) => {
-				const root = await createInitRouter('history')(page);
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
+				})(page);
 
 				await test.expect(root.evaluate(async (ctx) => {
 					const
@@ -246,7 +250,15 @@ test.describe('<b-router> passing transition parameters', () => {
 			].join(''),
 
 			async ({page}) => {
-				const root = await createInitRouter('history')(page);
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					},
+
+					second: {
+						path: '/second-page'
+					}
+				})(page);
 
 				await test.expect(root.evaluate(async (ctx) => {
 					const
@@ -284,7 +296,11 @@ test.describe('<b-router> passing transition parameters', () => {
 			'parameters should never be merged if we are navigating through the history',
 
 			async ({page}) => {
-				const root = await createInitRouter('history')(page);
+				const root = await createInitRouter('history', {
+					main: {
+						path: '/'
+					}
+				})(page);
 
 				await test.expect(root.evaluate(async (ctx) => {
 					const

--- a/src/components/base/b-router/test/unit/transition/routes.ts
+++ b/src/components/base/b-router/test/unit/transition/routes.ts
@@ -30,7 +30,7 @@ test.describe('<b-router> route handling', () => {
 	// eslint-disable-next-line max-lines-per-function
 	function generateSpecs(engineName: EngineName) {
 		test(
-			'should switch to the default page if the specified route was not found',
+			'the router should switch to the default page if the specified route could not be found',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -58,8 +58,8 @@ test.describe('<b-router> route handling', () => {
 
 		test(
 			[
-				'should switch to the original page using an alias path,',
-				'but the route name should match the name of the alias route'
+				'the router should switch to the original page, using an alias path.',
+				'However, the route name must match the name of the alias route'
 			].join(' '),
 
 			async ({page}) => {
@@ -90,7 +90,7 @@ test.describe('<b-router> route handling', () => {
 
 		test(
 			[
-				'should switch to the original page using an alias path with the parameters,',
+				'the router should switch to the original page using an alias path with parameters,',
 				'but the page URL should have the path of the alias route'
 			].join(' '),
 
@@ -134,8 +134,8 @@ test.describe('<b-router> route handling', () => {
 
 		test(
 			[
-				'should redirect to the main page using an alias path,',
-				'which points to a redirect route that subsequently redirects to the main page'
+				'the router should redirect to the main page using an alias path,',
+				'that points to a redirect route which in turn redirects to the main page'
 			].join(' '),
 
 			async ({page}) => {
@@ -165,7 +165,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should switch to the original page using the chained aliases',
+			'the router should switch to the original page using a chain of aliases',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -199,7 +199,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should redirect to the page using the redirect path without parameters',
+			'the router should redirect to the page using a redirect path without parameters',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -228,7 +228,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should redirect to the page using the redirect path with parameters',
+			'the router should redirect to the page using a redirect path with parameters',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -270,7 +270,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should redirect to the page using an alias path with the redirect',
+			'the router should redirect to the page using an alias path with the redirect',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -304,7 +304,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should redirect to the page using the chained redirect',
+			'the router should redirect to the page using a chained redirect',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -338,10 +338,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			[
-				'`back` and `forward` methods',
-				'should navigate back and forth between one page and another'
-			].join(' '),
+			'the `back` and `forward` methods should navigate back and forth between pages',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -372,7 +369,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'`go` method should navigate back and forth between one page and another',
+			'the `go` method should navigate back and forth between pages',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {
@@ -414,7 +411,7 @@ test.describe('<b-router> route handling', () => {
 		);
 
 		test(
-			'should transition by setting arbitrary properties on the root component',
+			'the router should be able to handle query params that are specified as functions',
 
 			async ({page}) => {
 				const root = await createInitRouter(engineName, {

--- a/src/components/base/b-router/test/unit/transition/routes.ts
+++ b/src/components/base/b-router/test/unit/transition/routes.ts
@@ -454,18 +454,25 @@ test.describe('<b-router> route handling', () => {
 			}
 		);
 
-		async function assertPathTransitionsTo(root: JSHandle<iStaticPage>, path: string, content: string) {
-			await test.expect(root.evaluate(async (ctx, path) => {
-				await ctx.router!.push(path);
-				return ctx.route!.meta.content;
-			}, path)).toBeResolvedTo(content);
-		}
-
-		async function assertActivePageIs(root: JSHandle<iStaticPage>, routeId: string) {
+		/**
+		 * Checks whether the name of the active route page matches the assertion.
+		 * The function returns a Promise.
+		 *
+		 * @param root
+		 * @param routeId
+		 */
+		async function assertActivePageIs(root: JSHandle<iStaticPage>, routeId: string): Promise<void> {
 			await test.expect(root.evaluate(({activePage}) => activePage)).resolves.toEqual(routeId);
 		}
 
-		async function assertRouteNameIs(root: JSHandle<iStaticPage>, name: string) {
+		/**
+		 * Checks whether the route name matches the assertion.
+		 * The function returns a Promise.
+		 *
+		 * @param root
+		 * @param name
+		 */
+		async function assertRouteNameIs(root: JSHandle<iStaticPage>, name: string): Promise<void> {
 			await test.expect(root.evaluate(({route}) => route!.name)).toBeResolvedTo(name);
 		}
 	}

--- a/src/components/base/b-router/test/unit/transition/routes.ts
+++ b/src/components/base/b-router/test/unit/transition/routes.ts
@@ -10,7 +10,7 @@ import type { JSHandle } from 'playwright';
 
 import test from 'tests/config/unit/test';
 
-import { createInitRouter } from 'components/base/b-router/test/helpers';
+import { createInitRouter, assertPathTransitionsTo } from 'components/base/b-router/test/helpers';
 import type { EngineName } from 'components/base/b-router/test/interface';
 
 import type iStaticPage from 'components/super/i-static-page/i-static-page';
@@ -425,6 +425,7 @@ test.describe('<b-router> route handling', () => {
 					second: {
 						path: '/second',
 						query: {
+							// The argument is an instance of the router, `r` is a link to the root component
 							rootParam: (o) => o.r.rootParam
 						}
 					}
@@ -433,16 +434,9 @@ test.describe('<b-router> route handling', () => {
 				});
 
 				const transition = root.evaluate(async (ctx) => {
-					const
-						router = ctx.router!;
-
-					await router.push('/second');
-					await router.push('/');
-
-					// eslint-disable-next-line require-atomic-updates
 					ctx['rootParam'] = 1;
 
-					await router.push('second');
+					await ctx.router!.push('second');
 
 					// eslint-disable-next-line require-atomic-updates
 					ctx['rootParam'] = undefined;

--- a/src/components/base/b-router/test/unit/transition/routes.ts
+++ b/src/components/base/b-router/test/unit/transition/routes.ts
@@ -15,6 +15,7 @@ import type { EngineName } from 'components/base/b-router/test/interface';
 
 import type iStaticPage from 'components/super/i-static-page/i-static-page';
 
+// eslint-disable-next-line max-lines-per-function
 test.describe('<b-router> route handling', () => {
 	test.beforeEach(async ({demoPage}) => {
 		await demoPage.goto();
@@ -26,6 +27,7 @@ test.describe('<b-router> route handling', () => {
 		});
 	});
 
+	// eslint-disable-next-line max-lines-per-function
 	function generateSpecs(engineName: EngineName) {
 				const root = await createInitRouter(engineName, {
 			main: {

--- a/src/components/base/b-router/test/unit/watch.ts
+++ b/src/components/base/b-router/test/unit/watch.ts
@@ -31,7 +31,17 @@ test.describe('<b-router> watch', () => {
  */
 function generateSpecs(engineName: EngineName) {
 	/* eslint-disable playwright/require-top-level-describe */
-	const initRouter = createInitRouter(engineName);
+	const initRouter = createInitRouter(engineName, {
+		main: {
+			path: '/',
+			content: 'Main page'
+		},
+
+		second: {
+			path: '/second',
+			content: 'Second page'
+		}
+	});
 
 	test('should watch for the `route` property changes', async ({page}) => {
 		const root = await initRouter(page);

--- a/src/components/base/b-router/test/unit/watch.ts
+++ b/src/components/base/b-router/test/unit/watch.ts
@@ -93,7 +93,7 @@ function generateSpecs(engineName: EngineName) {
 	);
 
 	test(
-		'should create link to the `route` property',
+		'should create a link to the `route` property',
 
 		async ({page}) => {
 			const root = await initRouter(page);


### PR DESCRIPTION
Глобальная настройка маршрутов удалена из helper'а createInitRouter, настройка роутера теперь осуществляется непосредственно перед тестами.
Поправлены некоторые тест-кейсы (более явная работа с маршрутами).
Внесены стилевые изменения.