### PR TITLE
Fix i-page interface and documentation

### DIFF
--- a/src/components/super/i-page/README.md
+++ b/src/components/super/i-page/README.md
@@ -49,10 +49,14 @@ Additionally, you can view the implemented traits or the parent component.
 The current page title.
 Basically this title is set via `document.title`.
 
-#### [pageTitleProp]
+If the prop value is defined as a function, it will be called (the result will be used as the title).
 
-The current page title.
+#### [pageDescriptionProp]
+
+The current page description.
 Basically this description is set via `<meta name="description" content="..."/>`.
+
+If the prop value is defined as a function, it will be called (the result will be used as the description content).
 
 #### [stagePageTitles]
 
@@ -102,11 +106,12 @@ class bMyPage extends iPage {
 #### scrollTo
 
 Scrolls the page to the specified coordinates.
+The scrolling can be done by specified coordinates (x, y) or by specified options.
 
 ```typescript
 class bMyPage extends iPage {
-  toTop() {
-    this.scrollTo({y: 0, behaviour: 'smooth'});
+  toTop(): void {
+    this.scrollTo({y: 0, behavior: 'smooth'});
   }
 }
 ```

--- a/src/components/super/i-page/i-page.ts
+++ b/src/components/super/i-page/i-page.ts
@@ -35,6 +35,7 @@ export default abstract class iPage extends iData implements iVisible {
 	/**
 	 * The current page title.
 	 * Basically this title is set via `document.title`.
+	 * If the prop value is defined as a function, it will be called (the result will be used as the title).
 	 */
 	@prop({type: [String, Function]})
 	readonly pageTitleProp: TitleValue = '';
@@ -42,6 +43,7 @@ export default abstract class iPage extends iData implements iVisible {
 	/**
 	 * The current page description.
 	 * Basically this description is set via `<meta name="description" content="..."/>`.
+	 * If the prop value is defined as a function, it will be called (the result will be used as the description content).
 	 */
 	@prop({type: [String, Function]})
 	readonly pageDescriptionProp: DescriptionValue = '';

--- a/src/components/super/i-page/i-page.ts
+++ b/src/components/super/i-page/i-page.ts
@@ -133,7 +133,7 @@ export default abstract class iPage extends iData implements iVisible {
 					globalThis.scrollTo(opts);
 
 				} catch {
-					globalThis.scrollTo(opts.left == null ? scrollX : opts.left, opts.top == null ? scrollY : opts.top);
+					globalThis.scrollTo(opts.left ?? scrollX, opts.top ?? scrollY);
 				}
 			} catch {}
 		};

--- a/src/components/super/i-page/interface.ts
+++ b/src/components/super/i-page/interface.ts
@@ -12,7 +12,7 @@ export type TitleValue<CTX extends iPage = iPage['unsafe']> =
 	string |
 	((ctx: CTX) => string);
 
-export type DescriptionValue = string;
+export type DescriptionValue<CTX extends iPage = iPage['unsafe']> = TitleValue<CTX>;
 
 export interface StageTitles<CTX extends iPage = iPage['unsafe']> extends Dictionary<TitleValue<CTX>> {
 	'[[DEFAULT]]': TitleValue<CTX>;


### PR DESCRIPTION
Обновлён тип `DescriptionValue` для пропа `pageDescriptionProp`, т.к. он тоже может быть задан функцией (соответствующий sync.link это предполагает).
Внесены исправления/дополнения в документацию.
В методе `scrollTo` тернарники заменены на ?? (замечание линтера).