### PR TITLE
Use `component :is` to render children

### DIFF
--- a/src/components/base/b-tree/CHANGELOG.md
+++ b/src/components/base/b-tree/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2023-11-??)
+
+#### :rocker: New Feature
+
+* Added `childrenTreeComponent` system field, default value is `b-tree`
+
 ## v4.0.0-beta.37 (2023-10-27)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-tree/b-tree.ss
+++ b/src/components/base/b-tree/b-tree.ss
@@ -59,7 +59,7 @@
 							:itemProps = itemProps |
 
 							:folded = getFoldedPropValue(el) |
-							:v-attrs = nestedTreeProps
+							:v-attrs = Object.reject(nestedTreeProps, ['isFunctional'])
 						.
 							< template &
 								#default = o |

--- a/src/components/base/b-tree/b-tree.ss
+++ b/src/components/base/b-tree/b-tree.ss
@@ -49,10 +49,11 @@
 
 				- block children
 					< .&__children v-if = hasChildren(el)
-						< b-tree.&__child &
+						< component.&__child &
 							ref = children |
 							v-func = nestedTreeProps.isFunctional |
 
+							:is = componentName |
 							:items = el.children |
 							:item = item |
 							:itemProps = itemProps |

--- a/src/components/base/b-tree/b-tree.ss
+++ b/src/components/base/b-tree/b-tree.ss
@@ -53,7 +53,7 @@
 							ref = children |
 							v-func = nestedTreeProps.isFunctional |
 
-							:is = componentName |
+							:is = childrenTreeComponent |
 							:items = el.children |
 							:item = item |
 							:itemProps = itemProps |

--- a/src/components/base/b-tree/b-tree.ts
+++ b/src/components/base/b-tree/b-tree.ts
@@ -176,6 +176,7 @@ class bTree extends iTreeProps implements iActiveItems, Foldable {
 			lazyRender: this.lazyRender,
 			renderChunks: this.renderChunks,
 			activeProp: this.active,
+			isFunctional: this.isFunctional,
 			nestedRenderFilter,
 			renderFilter
 		};

--- a/src/components/base/b-tree/b-tree.ts
+++ b/src/components/base/b-tree/b-tree.ts
@@ -71,6 +71,9 @@ class bTree extends iTreeProps implements iActiveItems, Foldable {
 		}
 	}
 
+	@system()
+	childrenTreeComponent: string = 'b-tree';
+
 	/**
 	 * {@link iActiveItems.activeStore}
 	 * {@link iActiveItems.linkActiveStore}


### PR DESCRIPTION
This allows to easily extend the b-tree component
without overriding the children block in the template