### PR TITLE
feat(template): add additional blocks for footer and header of component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2023-??-??)
+
+#### :boom: Breaking Change
+
+* Moved `dropdown` block from `helpers` to `bodyFooter` block `components/form/b-select`
+* Moved `limit` block from `helpers` to `bodyFooter` block `components/form/b-textarea`
+* Moved `message` block from `helpers` to `bodyFooter` block `components/super/i-block`
+
+#### :rocket: New Feature
+
+* Added new layout blocks - `bodyHeader` and `bodyFooter` `components/super/i-block`
+
 ## v4.0.0-beta.39 (2023-11-16)
 
 #### :house: Internal

--- a/src/components/form/b-select/CHANGELOG.md
+++ b/src/components/form/b-select/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2023-??-??)
+
+#### :boom: Breaking Change
+
+* Moved `dropdown` block from `helpers` to `bodyFooter` block
+
 ## v4.0.0-beta.26 (2023-09-20)
 
 #### :bug: Bug Fix

--- a/src/components/form/b-select/b-select.ss
+++ b/src/components/form/b-select/b-select.ss
@@ -135,7 +135,7 @@
 
 				- block icons
 
-	- block helpers
+	- block bodyFooter
 		- super
 
 		- block dropdown

--- a/src/components/form/b-textarea/CHANGELOG.md
+++ b/src/components/form/b-textarea/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2023-??-??)
+
+#### :boom: Breaking Change
+
+* Moved `limit` block from `helpers` to `bodyFooter` block
+
 ## v4.0.0-alpha.1 (2022-12-14)
 
 #### :boom: Breaking Change

--- a/src/components/form/b-textarea/b-textarea.ss
+++ b/src/components/form/b-textarea/b-textarea.ss
@@ -20,7 +20,7 @@
 		- block wrapper
 			+= self.nativeInput({attrs: {'@input': 'onEdit'}})
 
-	- block helpers
+	- block bodyFooter
 		- super
 
 		- block limit

--- a/src/components/super/i-block/CHANGELOG.md
+++ b/src/components/super/i-block/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2023-??-??)
+
+#### :rocket: New Feature
+
+* Added new layout blocks - `bodyHeader` and `bodyFooter`
+
 ## v4.0.0-beta.37 (2023-10-27)
 
 #### :rocket: New Feature

--- a/src/components/super/i-block/i-block.ss
+++ b/src/components/super/i-block/i-block.ss
@@ -246,11 +246,15 @@
 								- block helpers
 								- block providers
 
+								- block bodyHeader
+
 								< ${rootWrapper ? '_' : '?'}.&__root-wrapper
 									< ${overWrapper ? '_' : '?'}.&__over-wrapper
 										- block overWrapper
 
 									- block body
+
+								- block bodyFooter
 
 						- if !ssrRendering
 							< template v-if = !ssrRendering

--- a/src/components/super/i-input/CHANGELOG.md
+++ b/src/components/super/i-input/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2023-??-??)
+
+#### :boom: Breaking Change
+
+* Moved `message` block from `helpers` to `bodyFooter` block
+
 ## v4.0.0-beta.12 (2023-08-21)
 
 #### :bug: Bug Fix

--- a/src/components/super/i-input/i-input.ss
+++ b/src/components/super/i-input/i-input.ss
@@ -80,8 +80,9 @@
 				}
 			}) .
 
-	- block helpers
+	- block bodyFooter
 		- super
+
 		- block message
 			< template v-if = messageHelpers
 				- forEach ['error', 'info'] => el

--- a/src/components/super/i-static-page/i-static-page.component.ss
+++ b/src/components/super/i-static-page/i-static-page.component.ss
@@ -18,5 +18,9 @@
 		- block helpers
 		- block providers
 
+		- block bodyHeader
+
 		< .&__root-wrapper[.page-wrapper]
 			- block body
+
+		- block bodyFooter

--- a/src/components/super/i-static-page/i-static-page.html.ss
+++ b/src/components/super/i-static-page/i-static-page.html.ss
@@ -153,11 +153,15 @@
 					- block helpers
 					- block providers
 
+					- block bodyHeader
+
 					- if overWrapper
 						< .&__over-wrapper
 							- block overWrapper
 
 						- block body
+
+					- block bodyFooter
 
 				- block deps
 					- block styles


### PR DESCRIPTION
В https://github.com/V4Fire/Client/pull/1002 случился Breaking Change, который привел к тому, что верстка, заданная в `helpers` переехала на место перед основным телом компонента. Поэтому делаем новые специальные блоки, которые позволят задавать верстку до и после основного тела компонента