### PR TITLE
Fix intersection watcher (issues/1049)

### DIFF
--- a/src/core/dom/intersection-watcher/engines/interface.ts
+++ b/src/core/dom/intersection-watcher/engines/interface.ts
@@ -24,3 +24,5 @@ export interface WatcherPosition extends ElementPosition {
 
 export type RegisteredWatchers = Map<WatchLink, Writable<Watcher> | Set<Writable<Watcher>>>;
 export type ObservableElements = Map<Element, RegisteredWatchers>;
+
+export type PartialIOEntry = Pick<IntersectionObserverEntry, 'time'>;

--- a/src/core/dom/intersection-watcher/engines/intersection-observer.ts
+++ b/src/core/dom/intersection-watcher/engines/intersection-observer.ts
@@ -13,6 +13,8 @@ import { isElementInView, resolveScrollTarget } from 'core/dom/intersection-watc
 
 import type { Watcher } from 'core/dom/intersection-watcher/interface';
 
+import type { PartialIOEntry } from 'core/dom/intersection-watcher/engines/interface';
+
 export default class IntersectionObserverEngine extends AbstractEngine {
 	/**
 	 * A map of IntersectionObserver instances
@@ -156,7 +158,7 @@ export default class IntersectionObserverEngine extends AbstractEngine {
 	 * @param watcher
 	 * @param entry
 	 */
-	protected onObservableIn(watcher: Writable<Watcher>, entry: IntersectionObserverEntry): void {
+	protected onObservableIn(watcher: Writable<Watcher>, entry: PartialIOEntry): void {
 		watcher.time = entry.time;
 		watcher.timeIn = entry.time;
 
@@ -171,7 +173,7 @@ export default class IntersectionObserverEngine extends AbstractEngine {
 	 * @param watcher
 	 * @param entry
 	 */
-	protected onObservableOut(watcher: Writable<Watcher>, entry: IntersectionObserverEntry): void {
+	protected onObservableOut(watcher: Writable<Watcher>, entry: PartialIOEntry): void {
 		watcher.time = entry.time;
 		watcher.timeOut = entry.time;
 


### PR DESCRIPTION
Сделан фикс следующего бага в стратегии Intersection observer:

1. Регистрируется элемент
2. Элемент попадает во вьюпорт, срабатывает обработчик
3. Когда элемент находится во вьюпорте, выполняется регистрация этого же элемента с теми же настройками (threshold), но другим обработчиком
4. После повторной регистрации не происходит срабатывания обработчика (особенность нативного метода observe экземпляра класса Intersection Observer - обработчик вызывается сразу в момент вызова observe, но только если данный элемент ещё не был зарегистрирован)

Добавлен соответствующий тест.