### PR TITLE
fix(components/friends/block): make `$el` configurable

### DIFF
--- a/src/components/friends/block/class.ts
+++ b/src/components/friends/block/class.ts
@@ -96,6 +96,7 @@ class Block extends Friend {
 
 		if (originalNode != null && node != null && originalNode !== node) {
 			Object.defineProperty(this.ctx, '$el', {
+				configurable: true,
 				get: () => node
 			});
 


### PR DESCRIPTION
During component destruction this property could not be deleted, which could cause memory leaks