### PR TITLE
fix: add the getter to compiled routes

### DIFF
--- a/src/core/router/modules/helpers.ts
+++ b/src/core/router/modules/helpers.ts
@@ -375,6 +375,10 @@ export function compileStaticRoutes(routes: StaticRoutes, opts: CompileRoutesOpt
 					return this.meta.default;
 				},
 
+				get default(): boolean {
+					return this.meta.default;
+				},
+
 				meta: {
 					name,
 					external: isExternal.test(pattern),
@@ -412,6 +416,10 @@ export function compileStaticRoutes(routes: StaticRoutes, opts: CompileRoutesOpt
 
 				/** @deprecated */
 				get index(): boolean {
+					return this.meta.default;
+				},
+
+				get default(): boolean {
 					return this.meta.default;
 				},
 


### PR DESCRIPTION
Добавлен геттер `default` ко всем объектам `route`, формируемым хэлпером `compileStaticRoutes`. Фикс продиктован багом работы роутера в контексте webview: ложное представление перехода, при котором изменяется только query-параметр, как hard transition из-за первоначального отсутствия поля `default` в сравниваемом объекте маршрута.