### PR TITLE
Add parentheses for the wait function in loadModules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed the `wait` option in `loadModules` for SSR build `iBlock`
+
 ## v4.0.0-beta.67 (2024-02-26)
 
 #### :bug: Bug Fix

--- a/src/components/super/i-block/CHANGELOG.md
+++ b/src/components/super/i-block/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed the `wait` option in `loadModules` for SSR build
+
 ## v4.0.0-beta.65 (2024-02-21)
 
 #### :bug: Bug Fix

--- a/src/components/super/i-block/i-block.ss
+++ b/src/components/super/i-block/i-block.ss
@@ -127,7 +127,7 @@
 			{{
 				void(moduleLoader.addToBucket(${bucket}, {
 					id: ${interpolatedId},
-					load: () => (async () => ${filter}?.())().then(() => import('${path}')),
+					load: () => (async () => (${filter})?.())().then(() => import('${path}')),
 					ssr: false
 				}))
 			}}


### PR DESCRIPTION
Wait функция для SSR имеет вид: `() => { const {Promise} = global; return new Promise(() => {}); }`, далее она интепорлируется в шаблон и вызывается через `${filter}?.()`, чтобы корректно обрабатывать таким образом заданные функции завернул `${filter}`  в скобки 