### PR TITLE
fix(b-select): add missing methods to Block prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue with missing methods `element` and `elements` in the Block prototype `bSelect`
+
 ## v4.0.0-beta.70 (2024-03-05)
 
 #### :bug: Bug Fix

--- a/src/components/form/b-select/CHANGELOG.md
+++ b/src/components/form/b-select/CHANGELOG.md
@@ -13,6 +13,12 @@ Changelog
 
 #### :bug: Bug Fix
 
+* Fixed an issue with missing methods `element` and `elements` in the Block prototype
+
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
 * Fixed an error that the text in native mode was not synchronized with the value
 * Implemented correct switching between elements when pressing the `Tab` key
 

--- a/src/components/form/b-select/b-select.ts
+++ b/src/components/form/b-select/b-select.ts
@@ -15,7 +15,7 @@ import SyncPromise from 'core/promise/sync';
 
 import { derive } from 'core/functools/trait';
 
-import Block, { setElementMod, removeElementMod, getElementSelector } from 'components/friends/block';
+import Block, { setElementMod, removeElementMod, getElementSelector, element, elements } from 'components/friends/block';
 import DOM, { delegateElement } from 'components/friends/dom';
 
 import iItems, { IterationKey } from 'components/traits/i-items/i-items';
@@ -61,7 +61,7 @@ export * from 'components/form/b-select/interface';
 export { Value, FormValue };
 
 DOM.addToPrototype({delegateElement});
-Block.addToPrototype({setElementMod, removeElementMod, getElementSelector});
+Block.addToPrototype({setElementMod, removeElementMod, getElementSelector, element, elements});
 Mask.addToPrototype(MaskAPI);
 
 interface bSelect extends Trait<typeof iOpenToggle>, Trait<typeof iActiveItems>, Trait<typeof SelectEventHandlers> {}


### PR DESCRIPTION
Заметил при разработке такую ошибку, в тестах всё ок, полагаю как-то иначе в бандл попадают эти методы в тестах 

![image](https://github.com/V4Fire/Client/assets/51162910/67caaa92-8fb8-463c-a7f0-6c4ead3b86a3)
