### PR TITLE
Fix v-image to work correctly with cached images

### DIFF
--- a/src/components/directives/image/CHANGELOG.md
+++ b/src/components/directives/image/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+#### :bug: Bug Fix
+
+* Fixed the preview show time for cached images
+
 ## v4.0.0-beta.47 (2024-01-16)
 
 #### :bug: Bug Fix

--- a/src/components/directives/image/index.ts
+++ b/src/components/directives/image/index.ts
@@ -168,7 +168,7 @@ function mounted(el: HTMLElement, params: DirectiveParams, vnode: VNode): void {
 		}
 	}
 
-	async function onLoad() {
+	function onLoad() {
 		$a.off(group);
 
 		if (img == null) {

--- a/src/components/directives/image/index.ts
+++ b/src/components/directives/image/index.ts
@@ -163,6 +163,7 @@ function mounted(el: HTMLElement, params: DirectiveParams, vnode: VNode): void {
 
 		if (img.naturalWidth > 0) {
 			void onLoad();
+
 		} else {
 			onError();
 		}

--- a/src/components/directives/image/index.ts
+++ b/src/components/directives/image/index.ts
@@ -19,6 +19,7 @@ import { getDirectiveContext, getElementId } from 'core/component/directives/hel
 
 import { createImageElement, getCurrentSrc } from 'components/directives/image/helpers';
 import type { DirectiveParams } from 'components/directives/image/interface';
+import { ImageOrigin } from './interface';
 
 export * from 'components/directives/image/interface';
 
@@ -130,7 +131,7 @@ function mounted(el: HTMLElement, params: DirectiveParams, vnode: VNode): void {
 
 	switch (img.getAttribute('data-img')) {
 		case 'loaded':
-			void onLoad();
+			void onLoad(ImageOrigin.BROWSER_CACHE);
 			break;
 
 		case 'failed':
@@ -147,21 +148,21 @@ function mounted(el: HTMLElement, params: DirectiveParams, vnode: VNode): void {
 		}
 
 		if (!img.complete) {
-			$a.once(img, 'load', onLoad, group);
+			$a.once(img, 'load', onLoad.bind(null, ImageOrigin.SERVER), group);
 			$a.once(img, 'error', onError, group);
 
 			return;
 		}
 
 		if (img.naturalWidth > 0) {
-			void onLoad();
+			void onLoad(ImageOrigin.BROWSER_CACHE);
 
 		} else {
 			onError();
 		}
 	}
 
-	async function onLoad() {
+	async function onLoad(origin: ImageOrigin = ImageOrigin.SERVER) {
 		$a.off(group);
 
 		if (img == null) {
@@ -169,7 +170,9 @@ function mounted(el: HTMLElement, params: DirectiveParams, vnode: VNode): void {
 		}
 
 		try {
-			await $a.sleep(50, group);
+			if (origin === ImageOrigin.SERVER) {
+				await $a.sleep(50, group);
+			}
 
 			img.style.opacity = '1';
 

--- a/src/components/directives/image/index.ts
+++ b/src/components/directives/image/index.ts
@@ -18,7 +18,8 @@ import { setVNodePatchFlags, mergeProps } from 'core/component/render';
 import { getDirectiveContext, getElementId } from 'core/component/directives/helpers';
 
 import { createImageElement, getCurrentSrc } from 'components/directives/image/helpers';
-import type { DirectiveParams, ImageOrigin } from 'components/directives/image/interface';
+import { ImageOrigin } from 'components/directives/image/interface';
+import type { DirectiveParams } from 'components/directives/image/interface';
 
 export * from 'components/directives/image/interface';
 

--- a/src/components/directives/image/index.ts
+++ b/src/components/directives/image/index.ts
@@ -18,8 +18,7 @@ import { setVNodePatchFlags, mergeProps } from 'core/component/render';
 import { getDirectiveContext, getElementId } from 'core/component/directives/helpers';
 
 import { createImageElement, getCurrentSrc } from 'components/directives/image/helpers';
-import type { DirectiveParams } from 'components/directives/image/interface';
-import { ImageOrigin } from './interface';
+import type { DirectiveParams, ImageOrigin } from 'components/directives/image/interface';
 
 export * from 'components/directives/image/interface';
 

--- a/src/components/directives/image/interface.ts
+++ b/src/components/directives/image/interface.ts
@@ -16,6 +16,11 @@ export type OptionsResolver = (opts: ImageOptions) => ImageOptions;
 
 export type ImagePlaceholderOptions = Omit<ImageOptions, 'lazy' | 'preview' | 'broken'>;
 
+export const enum ImageOrigin {
+	SERVER = 'server',
+	BROWSER_CACHE = 'browser_cache'
+}
+
 export interface ImageOptions {
 	/**
 	 * The image URL.

--- a/src/components/directives/image/interface.ts
+++ b/src/components/directives/image/interface.ts
@@ -16,11 +16,6 @@ export type OptionsResolver = (opts: ImageOptions) => ImageOptions;
 
 export type ImagePlaceholderOptions = Omit<ImageOptions, 'lazy' | 'preview' | 'broken'>;
 
-export const enum ImageOrigin {
-	SERVER = 'server',
-	BROWSER_CACHE = 'browser_cache'
-}
-
 export interface ImageOptions {
 	/**
 	 * The image URL.


### PR DESCRIPTION
**Проблема:** 
Сейчас при успешной загрузке изображения добавляется таймаут в 50 мс, прежде, чем preview-изображение будет заменено на загруженное изображение.

Андрей не вспомнил зачем это было сделано, но я предполагаю, что смысл в том, чтобы не было моментального мигания заглушки, когда изображение загружается достаточно быстро.

Но это обернулось так, что теперь эти 50 мс добавляются даже для изображений, загруженных из кэша браузера. Выглядит так, что на главной едадила листаем слайдер, изображения подгружаются, но если листать обратно, выглядит будто предыдущие изображения загружаются повторно.

**Решение:**
Собственно, моё решение — убрать таймаут для изображений, которые браузер уже загрузил ранее. Если изображение еще не загружалось, то `onLoad` сработает, когда изображение будет готово, но не ранее, чем через 50 мс. 