### PR TITLE
fix(b-select): close dropdown on click outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
+* Fixed closing the dropdown when clicking on an element with stop propagation `bSelect`
 * Fixed an issue with missing methods `element` and `elements` in the Block prototype `bSelect`
 
 #### :house: Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 * Fixed an issue with missing methods `element` and `elements` in the Block prototype `bSelect`
 * Fixed closing the dropdown when clicking on an element with stop propagation `bSelect`
-* Fixed getting a component in `getComponent` when an additional selector is passed `components/friends/dom`
+* Fixed getting a component in `getComponent` when an additional root selector is passed `components/friends/dom`
 
 #### :house: Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* Fixed closing the dropdown when clicking on an element with stop propagation `bSelect`
 * Fixed an issue with missing methods `element` and `elements` in the Block prototype `bSelect`
+* Fixed closing the dropdown when clicking on an element with stop propagation `bSelect`
+* Fixed getting a component in `getComponent` when an additional selector is passed `components/friends/dom`
 
 #### :house: Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## 4.0.0-beta.?? (2024-03-??)
+
+#### :bug: Bug Fix
+
+* Fixed the issue of the dropdown not closing when clicking on an element with stop propagation `bSelect`
+* Fixed getting a component in `getComponent` when an additional root selector is passed `components/friends/dom`
+
 ## 4.0.0-beta.71 (2024-03-12)
 
 #### :rocket: New Feature

--- a/src/components/form/b-select/CHANGELOG.md
+++ b/src/components/form/b-select/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed closing the dropdown when clicking on an element with stop propagation
+
 ## v4.0.0-beta.70 (2024-03-05)
 
 #### :bug: Bug Fix

--- a/src/components/form/b-select/CHANGELOG.md
+++ b/src/components/form/b-select/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :bug: Bug Fix
 
-* Fixed closing the dropdown when clicking on an element with stop propagation
+* Fixed the issue of the dropdown not closing when clicking on an element with stop propagation
 
 ## v4.0.0-beta.70 (2024-03-05)
 

--- a/src/components/form/b-select/b-select.ts
+++ b/src/components/form/b-select/b-select.ts
@@ -443,7 +443,7 @@ class bSelect extends iSelectProps implements iOpenToggle, iActiveItems {
 	/** {@link iOpenToggle.initCloseHelpers} */
 	@hook('beforeDataCreate')
 	protected initCloseHelpers(events?: CloseHelperEvents): void {
-		iOpenToggle.initCloseHelpers(this, events);
+		iOpenToggle.initCloseHelpers(this, events, {capture: true});
 	}
 
 	/** {@link Values.init} */

--- a/src/components/form/b-select/test/unit/simple.ts
+++ b/src/components/form/b-select/test/unit/simple.ts
@@ -8,6 +8,7 @@
 
 import type { Page } from 'playwright';
 
+import { Component } from 'tests/helpers';
 import test from 'tests/config/unit/test';
 
 import { assertValueIs, createSelector, renderSelect, selectValue } from 'components/form/b-select/test/helpers';
@@ -185,6 +186,31 @@ test.describe('<b-select> simple usage', () => {
 				['SPAN', 'Bar']
 			]);
 		});
+
+		test('should close the dropdown when click on an element with .stopPropagation', async ({page}) => {
+			const btnText = 'buttonWithStopPropagation';
+			await Component.createComponent(page, 'b-button', {
+				attrs: {
+					'@click.stop': () => {},
+				},
+				children: {
+					default: btnText,
+				}
+			});
+
+			const target = await renderSelect(page, {
+				items: [
+					{label: 'Foo', value: 0},
+					{label: 'Bar', value: 1}
+				]
+			});
+
+			await target.evaluate(async ctx => await ctx.open());
+			await test.expect(page.locator(createSelector('dropdown')).isVisible()).resolves.toBeTruthy();
+
+			await page.getByText(btnText).click();
+			await test.expect(page.locator(createSelector('dropdown')).isHidden()).resolves.toBeTruthy();
+		})
 
 		test('should be rendered to a native <select> with `native = true`', async ({page}) => {
 			const target = await renderSelect(page, {

--- a/src/components/form/b-select/test/unit/simple.ts
+++ b/src/components/form/b-select/test/unit/simple.ts
@@ -205,7 +205,7 @@ test.describe('<b-select> simple usage', () => {
 				]
 			});
 
-			await target.evaluate(async ctx => await ctx.open());
+			await target.evaluate(ctx => ctx.open());
 			await test.expect(page.locator(createSelector('dropdown')).isVisible()).resolves.toBeTruthy();
 
 			await page.getByText(btnText).click();

--- a/src/components/form/b-select/test/unit/simple.ts
+++ b/src/components/form/b-select/test/unit/simple.ts
@@ -193,6 +193,7 @@ test.describe('<b-select> simple usage', () => {
 				attrs: {
 					'@click.stop': () => {},
 				},
+
 				children: {
 					default: btnText,
 				}

--- a/src/components/form/b-select/test/unit/simple.ts
+++ b/src/components/form/b-select/test/unit/simple.ts
@@ -190,12 +190,8 @@ test.describe('<b-select> simple usage', () => {
 		test('should close the dropdown when click on an element with .stopPropagation', async ({page}) => {
 			const btnText = 'buttonWithStopPropagation';
 			await Component.createComponent(page, 'b-button', {
-				attrs: {
-					'@click.stop': () => {},
-				},
-
 				children: {
-					default: btnText,
+					default: btnText
 				}
 			});
 
@@ -206,12 +202,12 @@ test.describe('<b-select> simple usage', () => {
 				]
 			});
 
-			await target.evaluate(ctx => ctx.open());
+			await target.evaluate((ctx) => ctx.open());
 			await test.expect(page.locator(createSelector('dropdown')).isVisible()).resolves.toBeTruthy();
 
 			await page.getByText(btnText).click();
 			await test.expect(page.locator(createSelector('dropdown')).isHidden()).resolves.toBeTruthy();
-		})
+		});
 
 		test('should be rendered to a native <select> with `native = true`', async ({page}) => {
 			const target = await renderSelect(page, {

--- a/src/components/friends/dom/CHANGELOG.md
+++ b/src/components/friends/dom/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed getting a component in `getComponent` when an additional selector is passed
+
 ## v4.0.0-alpha.1 (2022-12-14)
 
 #### :boom: Breaking Change

--- a/src/components/friends/dom/CHANGELOG.md
+++ b/src/components/friends/dom/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :bug: Bug Fix
 
-* Fixed getting a component in `getComponent` when an additional selector is passed
+* Fixed getting a component in `getComponent` when an additional root selector is passed
 
 ## v4.0.0-alpha.1 (2022-12-14)
 

--- a/src/components/friends/dom/component.ts
+++ b/src/components/friends/dom/component.ts
@@ -46,7 +46,7 @@ export function getComponent<T extends iBlock>(
 		query;
 
 	if (q != null) {
-		if (q.component?.instance instanceof iBlock) {
+		if (rootSelector === '' && q.component?.instance instanceof iBlock) {
 			return q.component;
 		}
 

--- a/src/components/friends/dom/test/unit/main.ts
+++ b/src/components/friends/dom/test/unit/main.ts
@@ -272,7 +272,7 @@ test.describe('friends/dom', () => {
 			test.expect(component).toBeNull();
 		});
 
-		test('should return `null` if the component with root selector is not found', async () => {
+		test('should return `null` if the component with the root selector is not found', async () => {
 			const component = await target.evaluate((ctx) => ctx.unsafe.dom.getComponent('.b-friends-dom-dummy', '.unreachable-root-selector'));
 
 			test.expect(component).toBeNull();

--- a/src/components/friends/dom/test/unit/main.ts
+++ b/src/components/friends/dom/test/unit/main.ts
@@ -278,7 +278,7 @@ test.describe('friends/dom', () => {
 			test.expect(component).toBeNull();
 		});
 
-		test('should find the component with correct root selector', async ({page}) => {
+		test('should find the component with the correct root selector', async ({page}) => {
 			const rootSelectorTarget = await Component.createComponent(page, 'b-button', {
 				attrs: {
 					class: 'correct-root-selector',

--- a/src/components/friends/dom/test/unit/main.ts
+++ b/src/components/friends/dom/test/unit/main.ts
@@ -281,7 +281,7 @@ test.describe('friends/dom', () => {
 		test('should find the component with the correct root selector', async ({page}) => {
 			const rootSelectorTarget = await Component.createComponent(page, 'b-button', {
 				attrs: {
-					class: 'correct-root-selector',
+					class: 'correct-root-selector'
 				}
 			});
 
@@ -289,7 +289,7 @@ test.describe('friends/dom', () => {
 			const targetComponentId = await rootSelectorTarget.evaluate((ctx) => ctx.componentId);
 
 			test.expect(componentId).toBe(targetComponentId);
-		})
+		});
 	});
 
 	test.describe('`watchForIntersection`', () => {

--- a/src/components/friends/dom/test/unit/main.ts
+++ b/src/components/friends/dom/test/unit/main.ts
@@ -271,6 +271,25 @@ test.describe('friends/dom', () => {
 
 			test.expect(component).toBeNull();
 		});
+
+		test('should return `null` if the component with root selector is not found', async () => {
+			const component = await target.evaluate((ctx) => ctx.unsafe.dom.getComponent('.b-friends-dom-dummy', '.unreachable-root-selector'));
+
+			test.expect(component).toBeNull();
+		});
+
+		test('should find the component with correct root selector', async ({page}) => {
+			const rootSelectorTarget = await Component.createComponent(page, 'b-button', {
+				attrs: {
+					class: 'correct-root-selector',
+				}
+			});
+
+			const componentId = await rootSelectorTarget.evaluate((ctx) => ctx.unsafe.dom.getComponent('.b-button', '.correct-root-selector')!.componentId);
+			const targetComponentId = await rootSelectorTarget.evaluate((ctx) => ctx.componentId);
+
+			test.expect(componentId).toBe(targetComponentId);
+		})
 	});
 
 	test.describe('`watchForIntersection`', () => {

--- a/src/components/traits/i-open/i-open.ts
+++ b/src/components/traits/i-open/i-open.ts
@@ -74,7 +74,7 @@ export default abstract class iOpen {
 	 * @param component
 	 * @param [events] - a map with events to listen
 	 */
-	static initCloseHelpers<T extends iBlock>(component: T & iOpen, events: CloseHelperEvents = {}): void {
+	static initCloseHelpers<T extends iBlock>(component: T & iOpen, events: CloseHelperEvents = {}, eventOpts: AddEventListenerOptions = {}): void {
 		const {
 			async: $a,
 			localEmitter: $e
@@ -92,7 +92,10 @@ export default abstract class iOpen {
 			$a.setTimeout(() => {
 				const opts = {
 					...helpersGroup,
-					options: {passive: false}
+					options: {
+						passive: false,
+						...eventOpts,
+					}
 				};
 
 				try {

--- a/src/components/traits/i-open/i-open.ts
+++ b/src/components/traits/i-open/i-open.ts
@@ -73,6 +73,7 @@ export default abstract class iOpen {
 	 *
 	 * @param component
 	 * @param [events] - a map with events to listen
+	 * @param [eventOpts] - an options for the event listener {@link AddEventListenerOptions}
 	 */
 	static initCloseHelpers<T extends iBlock>(component: T & iOpen, events: CloseHelperEvents = {}, eventOpts: AddEventListenerOptions = {}): void {
 		const {

--- a/src/components/traits/i-open/i-open.ts
+++ b/src/components/traits/i-open/i-open.ts
@@ -93,6 +93,7 @@ export default abstract class iOpen {
 			$a.setTimeout(() => {
 				const opts = {
 					...helpersGroup,
+
 					options: {
 						passive: false,
 						...eventOpts,

--- a/src/components/traits/i-open/i-open.ts
+++ b/src/components/traits/i-open/i-open.ts
@@ -75,7 +75,11 @@ export default abstract class iOpen {
 	 * @param [events] - a map with events to listen
 	 * @param [eventOpts] - an options for the event listener {@link AddEventListenerOptions}
 	 */
-	static initCloseHelpers<T extends iBlock>(component: T & iOpen, events: CloseHelperEvents = {}, eventOpts: AddEventListenerOptions = {}): void {
+	static initCloseHelpers<T extends iBlock>(
+		component: T & iOpen,
+		events: CloseHelperEvents = {},
+		eventOpts: AddEventListenerOptions = {}
+	): void {
 		const {
 			async: $a,
 			localEmitter: $e
@@ -96,7 +100,7 @@ export default abstract class iOpen {
 
 					options: {
 						passive: false,
-						...eventOpts,
+						...eventOpts
 					}
 				};
 


### PR DESCRIPTION
Столкнулся с проблемой, что дропдаун селекта не закрывается при клике на элемент с `.stopPropagation` и так же при клике на любой компонент с инстансом `iBlock`, мне кажется в таких кейсах закрытие дропдауна ожидаемое поведение.

### До фикса

https://github.com/V4Fire/Client/assets/51162910/f763931b-5ba9-4443-8e28-6a073d2d5254

### После фикса

https://github.com/V4Fire/Client/assets/51162910/5fc53415-54b8-4827-b9ef-48ef5e0d7077

