### PR TITLE
refactor: `addToPrototype` using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## 4.0.0-beta.?? (2024-03-??)
+
+#### :house: Internal
+
+* Changed the API usage of the `addToPrototype`
+
 ## 4.0.0-beta.73 (2024-03-19)
 
 #### :house: Internal

--- a/src/components/base/b-virtual-scroll/b-virtual-scroll.ts
+++ b/src/components/base/b-virtual-scroll/b-virtual-scroll.ts
@@ -71,9 +71,9 @@ export * from 'components/base/b-virtual-scroll/interface';
 
 export { RequestFn, RemoteData, RequestQueryFn, GetData };
 
-DOM.addToPrototype(watchForIntersection, appendChild);
-VDOM.addToPrototype(render, create);
-Block.addToPrototype(getFullElementName);
+DOM.addToPrototype({watchForIntersection, appendChild});
+VDOM.addToPrototype({render, create});
+Block.addToPrototype({getFullElementName});
 
 const
 	$$ = symbolGenerator();


### PR DESCRIPTION
Убираем поддержку API с остаточными параметрами в `addToPrototype`, см https://github.com/V4Fire/Core/pull/388

Больше нигде не используется в v4fire/client такой api, только в b-virtual-scroll