### PR TITLE
fix don't skip style load on loaded template

### DIFF
--- a/build/monic/attach-component-dependencies.js
+++ b/build/monic/attach-component-dependencies.js
@@ -102,10 +102,6 @@ module.exports = async function attachComponentDependencies(str, filePath) {
 			try {
 				decl += `
 	(() => {
-		if (TPLS['${dep}']) {
-			return;
-		}
-
 		requestAnimationFrame(async () => {
 			if (__webpack_component_styles_are_loaded__('${dep}')) {
 				return;


### PR DESCRIPTION
Try load styles even if template already loaded. This fix style load on templates loaded via another template without styles.