### PR TITLE
fix crash on undefined/null source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :bug: Bug Fix
+
+* Fixed crash on undefined value in renderList source `AsyncRender`
+
 ## 4.0.0-beta.81 (2024-04-01)
 
 #### :bug: Bug Fix

--- a/src/core/component/render/CHANGELOG.md
+++ b/src/core/component/render/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :bug: Bug Fix
+
+* Fixed crash on undefined value in renderList source
+
 ## v4.0.0-beta.57 (2024-02-13)
 
 #### :bug: Bug Fix

--- a/src/core/component/render/wrappers.ts
+++ b/src/core/component/render/wrappers.ts
@@ -293,7 +293,7 @@ export function wrapMergeProps<T extends typeof mergeProps>(original: T): T {
 export function wrapRenderList<T extends typeof renderList, C extends typeof withCtx>(original: T, withCtx: C): T {
 	return Object.cast(function renderList(
 		this: ComponentInterface,
-		src: Iterable<unknown> | Dictionary,
+		src: Iterable<unknown> | Dictionary | number | undefined | null,
 		cb: AnyFunction
 	) {
 		const
@@ -304,7 +304,7 @@ export function wrapRenderList<T extends typeof renderList, C extends typeof wit
 
 		const
 			vnodes = original(src, wrappedCb),
-			asyncRenderId = src[ASYNC_RENDER_ID];
+			asyncRenderId = src?.[ASYNC_RENDER_ID];
 
 		if (asyncRenderId != null) {
 			this.$emit('[[V_FOR_CB]]', {wrappedCb});


### PR DESCRIPTION
Добавлены возможные типы для source в методе renderList и исключено падение если на входе undefined/null
В оригинале есть function `renderList<T>(source: T, ...`