### PR TITLE
[issue/1203] Fix hide on-screen keyboard when there are validators on the input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 * Re-export `withMemo` `core/component/engines/vue3`
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :bug: Bug Fix
+
+* Fix hide on-screen keyboard when there are validators on the input field `iInput`
+
 ## v4.0.0-beta.82 (2024-04-02)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :boom: Breaking Change
+
+* The behavior of blocking the component during progress has been removed from `initModsEvents` `iProgress`
+
+#### :rocket: New Feature
+
+* Added a new static method `initDisableBehavior` `iProgress`
+
+#### :bug: Bug Fix
+
+* Fixed the issue of the on-screen keyboard disappearing when validators are specified on the input field `iInput`
+
 ## 4.0.0-beta.87 (2024-04-12)
 
 #### :bug: Bug Fix
@@ -45,12 +59,6 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 #### :house: Internal
 
 * Re-export `withMemo` `core/component/engines/vue3`
-
-## v4.0.0-beta.?? (2024-04-??)
-
-#### :bug: Bug Fix
-
-* Fix hide on-screen keyboard when there are validators on the input field `iInput`
 
 ## v4.0.0-beta.82 (2024-04-02)
 

--- a/src/components/form/b-button/b-button.ts
+++ b/src/components/form/b-button/b-button.ts
@@ -161,6 +161,7 @@ class bButton extends iButtonProps implements iOpenToggle, iVisible, iWidth, iSi
 		super.initModEvents();
 
 		iProgress.initModEvents(this);
+		iProgress.initDisableBehavior(this);
 		iAccess.initModEvents(this);
 		iOpenToggle.initModEvents(this);
 		iVisible.initModEvents(this);

--- a/src/components/super/i-input/CHANGELOG.md
+++ b/src/components/super/i-input/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :bug: Bug Fix
+
+* Fix hide on-screen keyboard when there are validators on the input field
+
 ## v4.0.0-beta.40 (2023-11-17)
 
 #### :boom: Breaking Change

--- a/src/components/super/i-input/CHANGELOG.md
+++ b/src/components/super/i-input/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :bug: Bug Fix
 
-* Fix hide on-screen keyboard when there are validators on the input field
+* Fixed the issue of the on-screen keyboard disappearing when validators are specified on the input field
 
 ## v4.0.0-beta.40 (2023-11-17)
 

--- a/src/components/super/i-input/i-input.ts
+++ b/src/components/super/i-input/i-input.ts
@@ -248,9 +248,6 @@ export default abstract class iInput extends iInputHandlers implements iVisible,
 			valid: CanUndef<ValidationResult<this['FormValue']>>,
 			failedValidation: CanUndef<ValidationError>;
 
-		const
-			focusedEl = document.activeElement;
-
 		for (const decl of this.validators) {
 			const
 				isArray = Object.isArray(decl),
@@ -315,10 +312,6 @@ export default abstract class iInput extends iInputHandlers implements iVisible,
 
 		} else {
 			void this.removeMod('valid');
-		}
-
-		if (focusedEl != null && 'focus' in focusedEl) {
-			(<HTMLElement>focusedEl).focus();
 		}
 
 		if (valid === true) {

--- a/src/components/traits/i-progress/CHANGELOG.md
+++ b/src/components/traits/i-progress/CHANGELOG.md
@@ -9,6 +9,16 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-04-??)
+
+#### :boom: Breaking Change
+
+* The behavior of blocking the component during progress has been removed from `initModsEvents`
+
+#### :rocket: New Feature
+
+* Added a new static method `initDisableBehavior`
+
 ## v3.0.0-rc.211 (2021-07-21)
 
 #### :boom: Breaking Change

--- a/src/components/traits/i-progress/README.md
+++ b/src/components/traits/i-progress/README.md
@@ -71,6 +71,10 @@ export default class bButton extends iBlock implements iProgress {
 }
 ```
 
+### initDisableBehavior
+
+Initializes the disable-on-progress behavior for the specified component.
+
 ## Styles
 
 The trait provides a bunch of optional styles for the component.

--- a/src/components/traits/i-progress/i-progress.ts
+++ b/src/components/traits/i-progress/i-progress.ts
@@ -13,9 +13,9 @@
  * @packageDocumentation
  */
 
+import type iAccess from 'components/traits/i-access/i-access';
 import type iBlock from 'components/super/i-block/i-block';
 import type { ModsDecl, ModEvent } from 'components/super/i-block/i-block';
-import type iAccess from 'components/traits/i-access/i-access';
 
 export default abstract class iProgress {
 	/**
@@ -50,8 +50,7 @@ export default abstract class iProgress {
 	}
 
 	/**
-	 * Initializes disable on progress behavior for the specified component
-	 *
+	 * Initializes the disable-on-progress behavior for the specified component
 	 * @param component
 	 */
 	static initDisableBehavior<T extends iBlock & iAccess>(component: T): void {

--- a/src/components/traits/i-progress/i-progress.ts
+++ b/src/components/traits/i-progress/i-progress.ts
@@ -15,6 +15,7 @@
 
 import type iBlock from 'components/super/i-block/i-block';
 import type { ModsDecl, ModEvent } from 'components/super/i-block/i-block';
+import type iAccess from 'components/traits/i-access/i-access';
 
 export default abstract class iProgress {
 	/**
@@ -38,16 +39,25 @@ export default abstract class iProgress {
 	static initModEvents<T extends iBlock>(component: T): void {
 		component.unsafe.localEmitter.on('block.mod.*.progress.*', (e: ModEvent) => {
 			if (e.value === 'false' || e.type === 'remove') {
-				void component.setMod('disabled', false);
-
 				if (e.type !== 'remove' || e.reason === 'removeMod') {
 					component.emit('progressEnd');
 				}
 
 			} else {
-				void component.setMod('disabled', true);
 				component.emit('progressStart');
 			}
+		});
+	}
+
+	/**
+	 * Initializes disable on progress behavior for the specified component
+	 *
+	 * @param component
+	 */
+	static initDisableBehavior<T extends iBlock & iAccess>(component: T): void {
+		component.unsafe.localEmitter.on('block.mod.*.progress.*', (e: ModEvent) => {
+			const isFinish = e.value === 'false' || e.type === 'remove';
+			void component.setMod('disabled', !isFinish);
 		});
 	}
 }


### PR DESCRIPTION
Убрал установку `disabled` для компнента на время валидации, и убран фикс востанавливающий фокус на копоненте после `disabled`.

Установка `disabled` приводила к потери фокуса и последующим дерганиям экранной клавиатуры и глюкам саджестов самой клавиатуры на устройствах с Android 12 и ниже.
При попытке спрятать экранную клавиатуру (жестом или кнопкой назад) запускалась валидация с циклом потери/установи фокуса, что приводило к повторному появлению клавиатуры.
Считаю `disabled` в процессе валидации (фактически на каждое нажатие клавиш) на поле ввода может приводить так же к потере вводимых пользователем символов, потере позиции курсора и прочим нежелательным спецэффектам.

Fixes #1203 