### PR TITLE
fix: add super call in baseMods override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.69.1 (2024-04-09)
+
+#### :bug: Bug Fix
+
+* Add super call in `baseMods` getter override `dummies/b-dummy/b-dummy`
+
 ## v3.69.0 (2024-03-29)
 
 #### :boom: Breaking Change

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/index.js",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "3.69.0",
+  "version": "3.69.1",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/dummies/b-dummy/CHANGELOG.md
+++ b/src/dummies/b-dummy/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.69.0 (2024-04-08)
+
+#### :bug: Bug Fix
+
+* Add super call in `baseMods` getter override
+
 ## v3.0.0-rc.199 (2021-06-16)
 
 #### :boom: Breaking Change

--- a/src/dummies/b-dummy/CHANGELOG.md
+++ b/src/dummies/b-dummy/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v3.69.0 (2024-04-08)
+## v3.69.1 (2024-04-09)
 
 #### :bug: Bug Fix
 

--- a/src/dummies/b-dummy/b-dummy.ts
+++ b/src/dummies/b-dummy/b-dummy.ts
@@ -125,7 +125,10 @@ class bDummy extends iData implements iLockPageScroll, iObserveDOM {
 	}
 
 	override get baseMods(): CanUndef<Readonly<ModsNTable>> {
-		return {foo: 'bar'};
+		return Object.freeze({
+			...super['baseModsGetter'],
+			foo: 'bar'
+		});
 	}
 
 	static override readonly daemons: typeof daemons = daemons;

--- a/src/dummies/b-dummy/b-dummy.ts
+++ b/src/dummies/b-dummy/b-dummy.ts
@@ -126,7 +126,7 @@ class bDummy extends iData implements iLockPageScroll, iObserveDOM {
 
 	override get baseMods(): CanUndef<Readonly<ModsNTable>> {
 		return Object.freeze({
-			...super['baseModsGetter'],
+			...super['baseModsGetter'](),
 			foo: 'bar'
 		});
 	}


### PR DESCRIPTION
In dummy override baseMods there was no call of super. It's affects on extended components from bDummy