### PR TITLE
fix: added watcher handler for v-in-view

### DIFF
--- a/src/components/base/b-virtual-scroll-new/b-virtual-scroll-new.ss
+++ b/src/components/base/b-virtual-scroll-new/b-virtual-scroll-new.ss
@@ -26,7 +26,8 @@
 				v-in-view = {
 					threshold: 0.0000001,
 					onEnter: onTombstonesEnter,
-					onLeave: onTombstonesLeave
+					onLeave: onTombstonesLeave,
+					handler: () => undefined
 				}
 			.
 				< .&__tombstone v-for = i in tombstoneCount || chunkSize


### PR DESCRIPTION
Исправление ошибки `ReferenceError: The watcher handler is not specified` для b-virtual-scroll-new.