### PR TITLE
refactor: use the `v-on-resize` directive to recalculate `b-bottom-slide` state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## 4.0.0-beta.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use the `v-on-resize` directive to recalculate `b-bottom-slide` state instead of `window:resize` and `DOMChange` watchers
+
 ## v4.0.0-beta.90 (2024-04-17)
 
 #### :rocket: New Feature

--- a/components-lock.json
+++ b/components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "ff36220f58f3461dcfe70b0dc9e204ac3514c46e11a5b0962eef65d4cc6f16f8",
+  "hash": "c1aec6e7c43a26e428f61c8cfba170a5e18402d1e733437b19f5a0bd401d4e8b",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -11,19 +11,27 @@
             "name": "b-bottom-slide",
             "parent": "i-block",
             "dependencies": [],
-            "libs": []
+            "libs": [
+              "components/directives/on-resize"
+            ]
           },
           "name": "b-bottom-slide",
           "parent": "i-block",
           "dependencies": [],
-          "libs": [],
+          "libs": [
+            "components/directives/on-resize"
+          ],
           "resolvedLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "components/directives/on-resize"
+            ]
           },
           "resolvedOwnLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "components/directives/on-resize"
+            ]
           },
           "type": "block",
           "mixin": false,

--- a/fat-html.components-lock.json
+++ b/fat-html.components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "a76ffbb038e5fc8e788df13e50f471c47aaf6242fba69f21789127a3d91694d2",
+  "hash": "be5328c11827c4226eafeea8c717f430dd61d15cbe46c2b7a1366ef9a79e40c8",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -11,19 +11,27 @@
             "name": "b-bottom-slide",
             "parent": "i-block",
             "dependencies": [],
-            "libs": []
+            "libs": [
+              "components/directives/on-resize"
+            ]
           },
           "name": "b-bottom-slide",
           "parent": "i-block",
           "dependencies": [],
-          "libs": [],
+          "libs": [
+            "components/directives/on-resize"
+          ],
           "resolvedLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "components/directives/on-resize"
+            ]
           },
           "resolvedOwnLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "components/directives/on-resize"
+            ]
           },
           "type": "block",
           "mixin": false,
@@ -1676,6 +1684,38 @@
           "logic": null,
           "styles": [
             "src/components/global/g-icon/g-icon.styl"
+          ],
+          "tpl": null,
+          "etpl": null
+        }
+      ],
+      [
+        "g-slider",
+        {
+          "index": "src/components/global/g-slider/index.js",
+          "declaration": {
+            "name": "g-slider",
+            "parent": null,
+            "dependencies": [],
+            "libs": []
+          },
+          "name": "g-slider",
+          "parent": null,
+          "dependencies": [],
+          "libs": [],
+          "resolvedLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "resolvedOwnLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "type": "global",
+          "mixin": false,
+          "logic": null,
+          "styles": [
+            "src/components/global/g-slider/g-slider.styl"
           ],
           "tpl": null,
           "etpl": null

--- a/src/components/base/b-bottom-slide/CHANGELOG.md
+++ b/src/components/base/b-bottom-slide/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## 4.0.0-beta.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use the `v-on-resize` directive to recalculate state instead of `window:resize` and `DOMChange` watchers
+
 ## 4.0.0-beta.85 (2024-04-11)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-bottom-slide/README.md
+++ b/src/components/base/b-bottom-slide/README.md
@@ -6,7 +6,7 @@ This module provides a component to create bottom sheet behavior that is similar
 
 * The component extends [[iBlock]].
 
-* The component implements [[iLockPageScroll]], [[iOpen]], [[iVisible]], [[iObserveDOM]], [[iHistory]] traits.
+* The component implements [[iLockPageScroll]], [[iOpen]], [[iVisible]], [[iHistory]] traits.
 
 ## Modifiers
 

--- a/src/components/base/b-bottom-slide/b-bottom-slide.ss
+++ b/src/components/base/b-bottom-slide/b-bottom-slide.ss
@@ -41,6 +41,9 @@
 			- block view
 				< .&__view &
 					ref = view |
+					v-on-resize = {
+						handler: recalculateState
+					} |
 					@touchstart = swipeControl.onPullStart |
 					@touchmove = swipeControl.onPull |
 					@touchend = swipeControl.onPullEnd

--- a/src/components/base/b-bottom-slide/b-bottom-slide.ts
+++ b/src/components/base/b-bottom-slide/b-bottom-slide.ts
@@ -20,7 +20,6 @@ import History from 'components/traits/i-history/history';
 import type iHistory from 'components/traits/i-history/i-history';
 
 import iLockPageScroll from 'components/traits/i-lock-page-scroll/i-lock-page-scroll';
-import iObserveDOM from 'components/traits/i-observe-dom/i-observe-dom';
 
 import iOpen from 'components/traits/i-open/i-open';
 import iVisible from 'components/traits/i-visible/i-visible';
@@ -46,12 +45,11 @@ Block.addToPrototype({getFullElementName});
 
 interface bBottomSlide extends
 	Trait<typeof iLockPageScroll>,
-	Trait<typeof iObserveDOM>,
 	Trait<typeof iOpen> {}
 
 @component()
-@derive(iLockPageScroll, iObserveDOM, iOpen)
-class bBottomSlide extends iBottomSlideProps implements iLockPageScroll, iObserveDOM, iOpen, iVisible, iHistory {
+@derive(iLockPageScroll, iOpen)
+class bBottomSlide extends iBottomSlideProps implements iLockPageScroll, iOpen, iVisible, iHistory {
 	override get unsafe(): UnsafeGetter<UnsafeBBottomSlide<this>> {
 		return Object.cast(this);
 	}
@@ -350,21 +348,6 @@ class bBottomSlide extends iBottomSlideProps implements iLockPageScroll, iObserv
 		// Loopback
 	}
 
-	/** {@link iObserveDOM.observe} */
-	@watch('heightMode')
-	@hook('mounted')
-	@wait('ready')
-	async initDOMObservers(): Promise<void> {
-		const
-			content = await this.waitRef<HTMLElement>('content', {label: $$.initDOMObservers});
-
-		iObserveDOM.observe(this, {
-			node: content,
-			childList: true,
-			subtree: true
-		});
-	}
-
 	protected override initModEvents(): void {
 		super.initModEvents();
 		this.sync.mod('heightMode', 'heightMode', String);
@@ -423,7 +406,7 @@ class bBottomSlide extends iBottomSlideProps implements iLockPageScroll, iObserv
 	/**
 	 * Recalculates the component state: sizes, positions, etc.
 	 */
-	@watch(['window:resize', 'localEmitter:DOMChange', ':history:transition'])
+	@watch(':history:transition')
 	@wait('ready')
 	protected async recalculateState(): Promise<void> {
 		try {

--- a/src/components/base/b-bottom-slide/index.js
+++ b/src/components/base/b-bottom-slide/index.js
@@ -7,4 +7,5 @@
  */
 
 package('b-bottom-slide')
-	.extends('i-block');
+	.extends('i-block')
+	.libs('components/directives/on-resize');

--- a/src/components/base/b-bottom-slide/test/unit/main.ts
+++ b/src/components/base/b-bottom-slide/test/unit/main.ts
@@ -7,6 +7,7 @@
  */
 
 /* eslint-disable max-lines-per-function */
+
 import sharp from 'sharp';
 
 import test from 'tests/config/unit/test';

--- a/src/components/base/b-bottom-slide/test/unit/main.ts
+++ b/src/components/base/b-bottom-slide/test/unit/main.ts
@@ -7,10 +7,11 @@
  */
 
 /* eslint-disable max-lines-per-function */
+import sharp from 'sharp';
 
 import test from 'tests/config/unit/test';
 
-import BOM from 'tests/helpers/bom';
+import { BOM, RequestInterceptor } from 'tests/helpers';
 
 import {
 
@@ -694,6 +695,65 @@ test.describe('<b-bottom-slide> functional cases', () => {
 				windowTopOffset = await getAbsoluteComponentWindowOffset(component);
 
 			test.expect(windowTopOffset).toBe(contentHeight * 2);
+		});
+
+		test('should recalculate the window geometry after image loading', async ({page}) => {
+			const
+				contentHeight = 40;
+
+			await page.addStyleTag({
+				content: `#test-div {height: ${contentHeight}px;}`
+			});
+
+			const component = await renderBottomSlide(page, {
+				heightMode: 'content'
+			});
+
+			await open(page, component);
+
+			const
+				imageSize = 300,
+				image = await sharp({
+					create: {
+						width: imageSize,
+						height: imageSize,
+						channels: 4,
+						background: {r: 255, g: 0, b: 0, alpha: 0.5}
+					}
+				})
+					.png()
+					.toBuffer(),
+				fakeImgUrl = 'https://fake-image.get';
+
+			const
+				interceptor = new RequestInterceptor(page, fakeImgUrl);
+
+			interceptor.response(200, image, {contentType: 'image/png'});
+
+			await interceptor.start();
+			await interceptor.responder();
+
+			await component.evaluate((_, fakeImgUrl) => {
+				const
+					el = document.getElementById('test-div'),
+					newEl = document.createElement('img');
+
+				newEl.src = fakeImgUrl;
+				newEl.style.display = 'block';
+				el?.insertAdjacentElement('afterend', newEl);
+			}, fakeImgUrl);
+
+			await BOM.waitForIdleCallback(page, {sleepAfterIdles: 200});
+
+			const
+				windowTopOffset = await getAbsoluteComponentWindowOffset(component);
+
+			test.expect(windowTopOffset).toBe(contentHeight);
+
+			await interceptor.respond();
+
+			await test.expect.poll(() => getAbsoluteComponentWindowOffset(component))
+				.toBe(contentHeight + imageSize);
 		});
 	});
 });


### PR DESCRIPTION
Use a directive instead watchers to catch changes that do not affect DOM (for example uploading an image)