### PR TITLE
refactor: use the `v-resize-observer` directive to recalculate `b-bottom-slide` state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## 3.??.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use the `v-resize-observer` directive to recalculate `b-bottom-slide` state instead of `window:resize` and `DOMChange` watchers
+
 ## v3.70.0 (2024-04-17)
 
 #### :rocket: New Feature

--- a/components-lock.json
+++ b/components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "03fa61a881bd04afbdd232c20cf9eca80b7179078fb85630fb59b00940df6e6e",
+  "hash": "16c496c09c2d6f423e835ff1f2d1cbf66e8974a499c340f2c8774c88471aad1d",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -11,19 +11,27 @@
             "name": "b-bottom-slide",
             "parent": "i-block",
             "dependencies": [],
-            "libs": []
+            "libs": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "name": "b-bottom-slide",
           "parent": "i-block",
           "dependencies": [],
-          "libs": [],
+          "libs": [
+            "core/component/directives/resize-observer"
+          ],
           "resolvedLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "resolvedOwnLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "type": "block",
           "mixin": false,

--- a/fat-html.components-lock.json
+++ b/fat-html.components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "2a22eb53756a6e760e1a06bf1948e34c9f61422a803f720888f02d15cf887846",
+  "hash": "97b772a9b9e7725ed696c082b0a77d35fef6fc74493c9efb88f96333f240e1b2",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -11,19 +11,27 @@
             "name": "b-bottom-slide",
             "parent": "i-block",
             "dependencies": [],
-            "libs": []
+            "libs": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "name": "b-bottom-slide",
           "parent": "i-block",
           "dependencies": [],
-          "libs": [],
+          "libs": [
+            "core/component/directives/resize-observer"
+          ],
           "resolvedLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "resolvedOwnLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/component/directives/resize-observer"
+            ]
           },
           "type": "block",
           "mixin": false,
@@ -1196,6 +1204,38 @@
         }
       ],
       [
+        "b-virtual-scroll-new",
+        {
+          "index": "src/base/b-virtual-scroll-new/index.js",
+          "declaration": {
+            "name": "b-virtual-scroll-new",
+            "parent": "i-data",
+            "dependencies": [],
+            "libs": []
+          },
+          "name": "b-virtual-scroll-new",
+          "parent": "i-data",
+          "dependencies": [],
+          "libs": [],
+          "resolvedLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "resolvedOwnLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "type": "block",
+          "mixin": false,
+          "logic": "src/base/b-virtual-scroll-new/b-virtual-scroll-new.ts",
+          "styles": [
+            "src/base/b-virtual-scroll-new/b-virtual-scroll-new.styl"
+          ],
+          "tpl": "src/base/b-virtual-scroll-new/b-virtual-scroll-new.ss",
+          "etpl": null
+        }
+      ],
+      [
         "b-window",
         {
           "index": "src/base/b-window/index.js",
@@ -1387,6 +1427,36 @@
           "styles": [
             "src/traits/i-access/i-access.styl"
           ],
+          "tpl": null,
+          "etpl": null
+        }
+      ],
+      [
+        "i-active-items",
+        {
+          "index": "src/traits/i-active-items/index.js",
+          "declaration": {
+            "name": "i-active-items",
+            "parent": null,
+            "dependencies": [],
+            "libs": []
+          },
+          "name": "i-active-items",
+          "parent": null,
+          "dependencies": [],
+          "libs": [],
+          "resolvedLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "resolvedOwnLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "type": "interface",
+          "mixin": false,
+          "logic": "src/traits/i-active-items/i-active-items.ts",
+          "styles": [],
           "tpl": null,
           "etpl": null
         }
@@ -1982,6 +2052,7 @@
               "b-select",
               "b-select-date",
               "b-virtual-scroll",
+              "b-virtual-scroll-new",
               "b-window",
               "b-sidebar",
               "b-slider",
@@ -1999,7 +2070,11 @@
               "b-dummy-control-list",
               "b-dummy-decorators"
             ],
-            "libs": []
+            "libs": [
+              "core/cookies",
+              "core/kv-storage/engines/cookie",
+              "models/demo/form"
+            ]
           },
           "name": "p-v4-components-demo",
           "parent": "i-static-page",
@@ -2023,6 +2098,7 @@
             "b-select",
             "b-select-date",
             "b-virtual-scroll",
+            "b-virtual-scroll-new",
             "b-window",
             "b-sidebar",
             "b-slider",
@@ -2040,14 +2116,26 @@
             "b-dummy-control-list",
             "b-dummy-decorators"
           ],
-          "libs": [],
+          "libs": [
+            "core/cookies",
+            "core/kv-storage/engines/cookie",
+            "models/demo/form"
+          ],
           "resolvedLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/cookies",
+              "core/kv-storage/engines/cookie",
+              "models/demo/form"
+            ]
           },
           "resolvedOwnLibs": {
             "%data": "%data:Set",
-            "%data:Set": []
+            "%data:Set": [
+              "core/cookies",
+              "core/kv-storage/engines/cookie",
+              "models/demo/form"
+            ]
           },
           "type": "page",
           "mixin": false,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/index.js",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "3.70.1",
+  "version": "3.70.2",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/base/b-bottom-slide/CHANGELOG.md
+++ b/src/base/b-bottom-slide/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## 3.??.?? (2024-04-??)
+
+#### :house: Internal
+
+* Use the `v-resize-observer` directive to recalculate state instead of `window:resize` and `DOMChange` watchers
+
 ## v3.32.1 (2022-12-26)
 
 #### :bug: Bug Fix

--- a/src/base/b-bottom-slide/README.md
+++ b/src/base/b-bottom-slide/README.md
@@ -6,7 +6,7 @@ This module provides a component to create bottom sheet behavior that is similar
 
 * The component extends [[iBlock]].
 
-* The component implements [[iLockPageScroll]], [[iOpen]], [[iVisible]], [[iObserveDOM]], [[iHistory]] traits.
+* The component implements [[iLockPageScroll]], [[iOpen]], [[iVisible]], [[iHistory]] traits.
 
 ## Modifiers
 

--- a/src/base/b-bottom-slide/b-bottom-slide.ss
+++ b/src/base/b-bottom-slide/b-bottom-slide.ss
@@ -40,6 +40,9 @@
 			- block view
 				< .&__view &
 					ref = view |
+					v-resize-observer = {
+						callback: recalculateState
+					} |
 					@touchstart = onPullStart |
 					@touchmove = onPull |
 					@touchend = onPullEnd

--- a/src/base/b-bottom-slide/b-bottom-slide.ts
+++ b/src/base/b-bottom-slide/b-bottom-slide.ts
@@ -20,7 +20,6 @@ import History from 'traits/i-history/history';
 import type iHistory from 'traits/i-history/i-history';
 
 import iLockPageScroll from 'traits/i-lock-page-scroll/i-lock-page-scroll';
-import iObserveDOM from 'traits/i-observe-dom/i-observe-dom';
 
 import iOpen from 'traits/i-open/i-open';
 import iVisible from 'traits/i-visible/i-visible';
@@ -54,7 +53,6 @@ export const
 
 interface bBottomSlide extends
 	Trait<typeof iLockPageScroll>,
-	Trait<typeof iObserveDOM>,
 	Trait<typeof iOpen> {}
 
 /**
@@ -62,8 +60,8 @@ interface bBottomSlide extends
  * @see https://material.io/develop/android/components/bottom-sheet-behavior/
  */
 @component()
-@derive(iLockPageScroll, iObserveDOM, iOpen)
-class bBottomSlide extends iBlock implements iLockPageScroll, iObserveDOM, iOpen, iVisible, iHistory {
+@derive(iLockPageScroll, iOpen)
+class bBottomSlide extends iBlock implements iLockPageScroll, iOpen, iVisible, iHistory {
 	/** @see [[iVisible.prototype.hideIfOffline]] */
 	@prop(Boolean)
 	readonly hideIfOffline: boolean = false;
@@ -532,21 +530,6 @@ class bBottomSlide extends iBlock implements iLockPageScroll, iObserveDOM, iOpen
 		// Loopback
 	}
 
-	/** @see [[iObserveDOM.initObservers]] */
-	@watch('heightMode')
-	@hook('mounted')
-	@wait('ready')
-	async initDOMObservers(): Promise<void> {
-		const
-			content = await this.waitRef<HTMLElement>('content', {label: $$.initDOMObservers});
-
-		iObserveDOM.observe(this, {
-			node: content,
-			childList: true,
-			subtree: true
-		});
-	}
-
 	protected override initModEvents(): void {
 		super.initModEvents();
 		this.sync.mod('heightMode', 'heightMode', String);
@@ -856,7 +839,7 @@ class bBottomSlide extends iBlock implements iLockPageScroll, iObserveDOM, iOpen
 	/**
 	 * Recalculates a component state: sizes, positions, etc.
 	 */
-	@watch(['window:resize', ':DOMChange', ':history:transition'])
+	@watch(':history:transition')
 	@wait('ready')
 	protected async recalculateState(): Promise<void> {
 		try {

--- a/src/base/b-bottom-slide/index.js
+++ b/src/base/b-bottom-slide/index.js
@@ -7,4 +7,5 @@
  */
 
 package('b-bottom-slide')
-	.extends('i-block');
+	.extends('i-block')
+	.libs('core/component/directives/resize-observer');


### PR DESCRIPTION
Use a directive instead watchers to catch changes that do not affect DOM (for example uploading an image)