### PR TITLE
fix: add conditional render of the page title

### DIFF
--- a/src/components/super/i-static-page/i-static-page.html.ss
+++ b/src/components/super/i-static-page/i-static-page.html.ss
@@ -120,8 +120,9 @@
 							+= h.getFaviconsDecl(canInlineSourceCode, Boolean(config.webpack.dynamicPublicPath()))
 
 					- block title
-						< title
-							{title}
+						- if !config.webpack.hydration()
+							< title
+								{title}
 
 					- block assets
 						+= h.getAssetsDecl({inline: canInlineSourceCode && !assetsRequest, wrap: true})

--- a/src/components/super/i-static-page/i-static-page.html.ss
+++ b/src/components/super/i-static-page/i-static-page.html.ss
@@ -120,7 +120,7 @@
 							+= h.getFaviconsDecl(canInlineSourceCode, Boolean(config.webpack.dynamicPublicPath()))
 
 					- block title
-						- if !config.webpack.hydration()
+						- if !HYDRATION
 							< title
 								{title}
 


### PR DESCRIPTION
Не рендерить заголовок страницы в html-шаблоне при гидратации. Этим избегаем дублирования элемента `title` на странице, так как мета-информация из `pageMetaData` встраивается в шаблон на bff-сервере.