### PR TITLE
fix: reset cache after restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Do not store computed values in the cache before the functional component is fully created.
+  This fixes hard-to-detect bugs that can occur due to context inheritance.
+  See: https://github.com/V4Fire/Client/issues/1292 `core/component/accessor`
+
 ## v4.0.0-beta.105 (2024-06-24)
 
 #### :bug: Bug Fix

--- a/components-lock.json
+++ b/components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "4f860c4c341ae3b773f6d53acff95bc7db5406bddf59f629c4aa523c5af1df94",
+  "hash": "56c4940e4f7a7e13a5d557ef79d87d4abeb6dee36e79e043ee1919a9a53e38b5",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -702,12 +702,18 @@
           "declaration": {
             "name": "b-functional-dummy",
             "parent": "b-dummy",
-            "dependencies": [],
+            "dependencies": [
+              "b-functional-button-dummy",
+              "b-functional-getters-dummy"
+            ],
             "libs": []
           },
           "name": "b-functional-dummy",
           "parent": "b-dummy",
-          "dependencies": [],
+          "dependencies": [
+            "b-functional-button-dummy",
+            "b-functional-getters-dummy"
+          ],
           "libs": [],
           "resolvedLibs": {
             "%data": "%data:Set",
@@ -724,6 +730,38 @@
             "src/core/component/functional/test/b-functional-dummy/b-functional-dummy.styl"
           ],
           "tpl": "src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ss",
+          "etpl": null
+        }
+      ],
+      [
+        "b-functional-getters-dummy",
+        {
+          "index": "src/core/component/functional/test/b-functional-getters-dummy/index.js",
+          "declaration": {
+            "name": "b-functional-getters-dummy",
+            "parent": "b-dummy",
+            "dependencies": [],
+            "libs": []
+          },
+          "name": "b-functional-getters-dummy",
+          "parent": "b-dummy",
+          "dependencies": [],
+          "libs": [],
+          "resolvedLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "resolvedOwnLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "type": "block",
+          "mixin": false,
+          "logic": "src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts",
+          "styles": [
+            "src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.styl"
+          ],
+          "tpl": "src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ss",
           "etpl": null
         }
       ],

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "ts-jest": "29.1.0"
   },
   "peerDependencies": {
-    "@v4fire/core": "^4.0.0-alpha.34",
+    "@v4fire/core": "^4.0.0-alpha.37",
     "webpack": "^5.82.1"
   },
   "resolutions": {

--- a/src/core/component/accessor/CHANGELOG.md
+++ b/src/core/component/accessor/CHANGELOG.md
@@ -9,6 +9,14 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Do not store computed values in the cache before the functional component is fully created.
+  This fixes hard-to-detect bugs that can occur due to context inheritance.
+  See: https://github.com/V4Fire/Client/issues/1292
+
 ## v4.0.0-beta.51 (2024-01-19)
 
 #### :bug: Bug Fix

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -70,8 +70,7 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 		meta: {params: {deprecatedProps}}
 	} = component.unsafe;
 
-	const
-		isFunctional = meta.params.functional === true;
+	const isFunctional = meta.params.functional === true;
 
 	Object.entries(meta.accessors).forEach(([name, accessor]) => {
 		const canSkip =
@@ -91,8 +90,7 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 		});
 	});
 
-	const
-		computedFields = Object.entries(meta.computedFields);
+	const computedFields = Object.entries(meta.computedFields);
 
 	computedFields.forEach(([name, computed]) => {
 		const canSkip =

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -108,44 +108,47 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 		const get = function get(this: typeof component): unknown {
 			const {hook} = this;
 
-			// We should not use the getter's cache until the component is fully created,
-			// because until that moment, we cannot track changes to dependent entities
-			// and reset the cache when they change.
-			// This can lead to hard-to-detect errors.
-			const canUseCache = !SSR && beforeHooks[hook] == null;
+			const getValue = () => computed.get!.call(this);
 
-			if (cacheStatus in get) {
-				// If a getter already has a cached result and is used inside a template,
-				// it is not possible to track its effect, as the value is not recalculated.
-				// This can lead to a problem where one of the entities on which the getter depends is updated,
-				// but the template is not.
-				// To avoid this problem, we explicitly touch all dependent entities.
-				// For functional components, this problem does not exist, as no change in state can trigger their re-render.
-				if (!isFunctional && hook !== 'created') {
-					meta.watchDependencies.get(name)?.forEach((path) => {
-						Object.get(this, path);
-					});
+			if (
+				!SSR &&
 
-					['Store', 'Prop'].forEach((postfix) => {
-						const
-							path = name + postfix;
-
-						if (path in this) {
+				// We should not use the getter's cache until the component is fully created,
+				// because until that moment, we cannot track changes to dependent entities
+				// and reset the cache when they change.
+				// This can lead to hard-to-detect errors.
+				beforeHooks[hook] == null
+			) {
+				if (cacheStatus in get) {
+					// If a getter already has a cached result and is used inside a template,
+					// it is not possible to track its effect, as the value is not recalculated.
+					// This can lead to a problem where one of the entities on which the getter depends is updated,
+					// but the template is not.
+					// To avoid this problem, we explicitly touch all dependent entities.
+					// For functional components, this problem does not exist, as no change in state can trigger their re-render.
+					if (!isFunctional && hook !== 'created') {
+						meta.watchDependencies.get(name)?.forEach((path) => {
 							Object.get(this, path);
-						}
-					});
+						});
+
+						['Store', 'Prop'].forEach((postfix) => {
+							const
+								path = name + postfix;
+
+							if (path in this) {
+								Object.get(this, path);
+							}
+						});
+					}
+
+				} else {
+					get[cacheStatus] = getValue();
 				}
 
 				return get[cacheStatus];
 			}
 
-			const value = computed.get!.call(this);
-
-			if (canUseCache) {
-				get[cacheStatus] = value;
-			}
-
-			return value;
+			return getValue();
 		};
 
 		Object.defineProperty(component, name, {

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -108,45 +108,40 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 		const get = function get(this: typeof component): unknown {
 			const {hook} = this;
 
+			// We should not use the getter's cache until the component is fully created,
+			// because until that moment, we cannot track changes to dependent entities
+			// and reset the cache when they change.
+			// This can lead to hard-to-detect errors.
+			const canUseCache = !SSR && beforeHooks[hook] == null;
+
 			if (cacheStatus in get) {
-				// We should not use the getter's cache until the component is fully created,
-				// because until that moment, we cannot track changes to dependent entities
-				// and reset the cache when they change.
-				// This can lead to hard-to-detect errors.
-				const canUseCache = beforeHooks[hook] == null;
+				// If a getter already has a cached result and is used inside a template,
+				// it is not possible to track its effect, as the value is not recalculated.
+				// This can lead to a problem where one of the entities on which the getter depends is updated,
+				// but the template is not.
+				// To avoid this problem, we explicitly touch all dependent entities.
+				// For functional components, this problem does not exist, as no change in state can trigger their re-render.
+				if (!isFunctional && hook !== 'created') {
+					meta.watchDependencies.get(name)?.forEach((path) => {
+						Object.get(this, path);
+					});
 
-				if (canUseCache) {
-					// If a getter already has a cached result and is used inside a template,
-					// it is not possible to track its effect, as the value is not recalculated.
-					// This can lead to a problem where one of the entities on which the getter depends is updated,
-					// but the template is not.
-					// To avoid this problem, we explicitly touch all dependent entities.
-					// For functional components, this problem does not exist, as no change in state can trigger their re-render.
-					if (!isFunctional && hook !== 'created') {
-						meta.watchDependencies.get(name)?.forEach((path) => {
+					['Store', 'Prop'].forEach((postfix) => {
+						const
+							path = name + postfix;
+
+						if (path in this) {
 							Object.get(this, path);
-						});
-
-						['Store', 'Prop'].forEach((postfix) => {
-							const
-								path = name + postfix;
-
-							if (path in this) {
-								Object.get(this, path);
-							}
-						});
-					}
-
-					return get[cacheStatus];
+						}
+					});
 				}
 
-				delete get[cacheStatus];
+				return get[cacheStatus];
 			}
 
-			const
-				value = computed.get!.call(this);
+			const value = computed.get!.call(this);
 
-			if (!SSR) {
+			if (canUseCache) {
 				get[cacheStatus] = value;
 			}
 

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -110,9 +110,13 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 				{hook} = this;
 
 			if (cacheStatus in get) {
-				// Need to explicitly touch all dependencies for Vue
-				if (beforeHooks[hook] == null) {
-					if (hook !== 'created') {
+				const canUseCache =
+					beforeHooks[hook] == null ||
+					isFunctional && hook !== 'created';
+
+				if (canUseCache) {
+					// It is necessary to explicitly touch all the dependencies of the getter to track the effect
+					if (!isFunctional && hook !== 'created') {
 						meta.watchDependencies.get(name)?.forEach((path) => {
 							Object.get(this, path);
 						});

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -113,8 +113,7 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 				// because until that moment, we cannot track changes to dependent entities
 				// and reset the cache when they change.
 				// This can lead to hard-to-detect errors.
-				// For functional components, we also should not use the cache until it is fully created.
-				const canUseCache = beforeHooks[hook] == null && (!isFunctional || hook !== 'created');
+				const canUseCache = beforeHooks[hook] == null;
 
 				if (canUseCache) {
 					// If a getter already has a cached result and is used inside a template,
@@ -140,6 +139,8 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 
 					return get[cacheStatus];
 				}
+
+				delete get[cacheStatus];
 			}
 
 			const

--- a/src/core/component/accessor/index.ts
+++ b/src/core/component/accessor/index.ts
@@ -106,44 +106,43 @@ export function attachAccessorsFromMeta(component: ComponentInterface): void {
 		const get = function get(this: typeof component): unknown {
 			const {hook} = this;
 
-			if (cacheStatus in get) {
-				// We should not use the getter's cache until the component is fully created,
-				// because until that moment, we cannot track changes to dependent entities
-				// and reset the cache when they change.
-				// This can lead to hard-to-detect errors.
-				const canUseCache = beforeHooks[hook] == null;
+			// We should not use the getter's cache until the component is fully created,
+			// because until that moment, we cannot track changes to dependent entities
+			// and reset the cache when they change.
+			// This can lead to hard-to-detect errors.
+			const canUseCache = beforeHooks[hook] == null;
 
-				if (canUseCache) {
-					// If a getter already has a cached result and is used inside a template,
-					// it is not possible to track its effect, as the value is not recalculated.
-					// This can lead to a problem where one of the entities on which the getter depends is updated,
-					// but the template is not.
-					// To avoid this problem, we explicitly touch all dependent entities.
-					// For functional components, this problem does not exist, as no change in state can trigger their re-render.
-					if (!isFunctional && hook !== 'created') {
-						meta.watchDependencies.get(name)?.forEach((path) => {
+			if (canUseCache && cacheStatus in get) {
+				// If a getter already has a cached result and is used inside a template,
+				// it is not possible to track its effect, as the value is not recalculated.
+				// This can lead to a problem where one of the entities on which the getter depends is updated,
+				// but the template is not.
+				// To avoid this problem, we explicitly touch all dependent entities.
+				// For functional components, this problem does not exist, as no change in state can trigger their re-render.
+				if (!isFunctional && hook !== 'created') {
+					meta.watchDependencies.get(name)?.forEach((path) => {
+						Object.get(this, path);
+					});
+
+					['Store', 'Prop'].forEach((postfix) => {
+						const
+							path = name + postfix;
+
+						if (path in this) {
 							Object.get(this, path);
-						});
-
-						['Store', 'Prop'].forEach((postfix) => {
-							const
-								path = name + postfix;
-
-							if (path in this) {
-								Object.get(this, path);
-							}
-						});
-					}
-
-					return get[cacheStatus];
+						}
+					});
 				}
 
-				delete get[cacheStatus];
+				return get[cacheStatus];
 			}
 
 			const value = computed.get!.call(this);
 
-			if (!SSR) {
+			// Due to context inheritance in the functional components
+			// we should not cache the computed value until the component is created
+			// @see https://github.com/V4Fire/Client/issues/1292
+			if (!SSR && (canUseCache || !isFunctional)) {
 				get[cacheStatus] = value;
 			}
 

--- a/src/core/component/functional/helpers.ts
+++ b/src/core/component/functional/helpers.ts
@@ -160,8 +160,4 @@ export function inheritContext(
 			}
 		});
 	});
-
-	Object.keys(ctx.meta.computedFields).forEach((name) => {
-		delete Object.getOwnPropertyDescriptor(ctx, name)?.get?.[cacheStatus];
-	});
 }

--- a/src/core/component/functional/helpers.ts
+++ b/src/core/component/functional/helpers.ts
@@ -7,7 +7,6 @@
  */
 
 import * as init from 'core/component/init';
-import { cacheStatus } from 'core/component/watch';
 import type { ComponentInterface, ComponentElement, ComponentDestructorOptions } from 'core/component/interface';
 
 /**

--- a/src/core/component/functional/helpers.ts
+++ b/src/core/component/functional/helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import * as init from 'core/component/init';
+import { cacheStatus } from 'core/component/watch';
 import type { ComponentInterface, ComponentElement, ComponentDestructorOptions } from 'core/component/interface';
 
 /**
@@ -158,5 +159,9 @@ export function inheritContext(
 				}
 			}
 		});
+	});
+
+	Object.keys(ctx.meta.computedFields).forEach((name) => {
+		delete Object.getOwnPropertyDescriptor(ctx, name)?.get?.[cacheStatus];
 	});
 }

--- a/src/core/component/functional/index.ts
+++ b/src/core/component/functional/index.ts
@@ -16,5 +16,4 @@ export * from 'core/component/functional/interface';
 
 //#if runtime has dummyComponents
 import('core/component/functional/test/b-functional-dummy');
-import('core/component/functional/test/b-functional-button-dummy');
 //#endif

--- a/src/core/component/functional/test/b-functional-button-dummy/b-functional-button-dummy.ss
+++ b/src/core/component/functional/test/b-functional-button-dummy/b-functional-button-dummy.ss
@@ -19,5 +19,5 @@
 		}, attrs) .
 
 	- block body
-		< . v-hook = {unmounted: reset}
+		< span v-hook = {unmounted: reset}
 			Click!

--- a/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ss
+++ b/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ss
@@ -13,6 +13,8 @@
 - template index() extends ['b-dummy'].index
 	- block body
 		< p
-			Click count: {{clickCount}}
+			Counter: {{counter}}
 
-		< b-functional-button-dummy ref = button | @click:component = onClick
+		< template v-if = stage === 'main'
+			< b-functional-button-dummy ref = button | @click:component = onClick
+

--- a/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ts
+++ b/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ts
@@ -9,7 +9,9 @@
 /* eslint-disable @v4fire/require-jsdoc */
 
 import bDummy, { component, field, system } from 'components/dummies/b-dummy/b-dummy';
+
 import type bFunctionalButtonDummy from 'core/component/functional/test/b-functional-button-dummy/b-functional-button-dummy';
+import type bFunctionalGettersDummy from 'core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy';
 
 export * from 'components/dummies/b-dummy/b-dummy';
 
@@ -28,6 +30,7 @@ export default class bFunctionalDummy extends bDummy {
 
 	protected override $refs!: bDummy['$refs'] & {
 		button?: bFunctionalButtonDummy;
+		gettersDummy?: bFunctionalGettersDummy;
 	};
 
 	syncStoreWithState(): void {

--- a/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ts
+++ b/src/core/component/functional/test/b-functional-dummy/b-functional-dummy.ts
@@ -21,20 +21,20 @@ export * from 'components/dummies/b-dummy/b-dummy';
 
 export default class bFunctionalDummy extends bDummy {
 	@field()
-	clickCount: number = 0;
+	counter: number = 0;
 
 	@system()
-	clickCountStore: number = 0;
+	counterStore: number = 0;
 
 	protected override $refs!: bDummy['$refs'] & {
-		button: bFunctionalButtonDummy;
+		button?: bFunctionalButtonDummy;
 	};
 
-	updateClickCountField(): void {
-		this.clickCount = this.clickCountStore;
+	syncStoreWithState(): void {
+		this.counter = this.counterStore;
 	}
 
 	onClick(): void {
-		this.clickCountStore += 1;
+		this.counterStore += 1;
 	}
 }

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ss
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ss
@@ -12,11 +12,8 @@
 
 - template index() extends ['b-dummy'].index
 	- block body
-		< p
-			Counter: {{counter}}
+		< .
+			Value:
 
-		< template v-if = stage === 'main'
-			< b-functional-button-dummy ref = button | @click:component = onClick
-
-		< template v-if = stage === 'getters'
-			< b-functional-getters-dummy ref = gettersDummy
+			< span ref = container
+				{{ value }}

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.styl
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.styl
@@ -6,9 +6,10 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-package('b-functional-dummy')
-	.extends('b-dummy')
-	.dependencies(
-		'b-functional-button-dummy',
-		'b-functional-getters-dummy'
-	);
+@import "components/dummies/b-dummy/b-dummy.styl"
+
+$p = {
+
+}
+
+b-functional-getters-dummy extends b-dummy

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
@@ -1,0 +1,46 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+/* eslint-disable @v4fire/require-jsdoc */
+
+import bDummy, { component, system, computed } from 'components/dummies/b-dummy/b-dummy';
+import type { Item } from 'core/component/functional/test/b-functional-getters-dummy/interface';
+
+import { item } from 'core/component/functional/test/b-functional-getters-dummy/const';
+
+export * from 'components/dummies/b-dummy/b-dummy';
+
+@component({functional: true})
+export default class bFunctionalGettersDummy extends bDummy {
+	@system()
+	itemStore?: CanUndef<Item>;
+
+	protected override $refs!: bDummy['$refs'] & {
+		container: HTMLElement;
+	};
+
+	@computed({dependencies: ['item']})
+	get value(): string {
+		return String(this.item?.value);
+	}
+
+	@computed()
+	get item(): CanUndef<Item> {
+		return this.field.get('itemStore');
+	}
+
+	set item(value: Item) {
+		this.field.set('itemStore', value);
+	}
+
+	mounted(): void {
+		this.console.log('mounted');
+		this.item = item;
+		this.$refs.container.textContent = this.value;
+	}
+}

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
@@ -34,7 +34,7 @@ export default class bFunctionalGettersDummy extends bDummy {
 		return this.field.get('itemStore');
 	}
 
-	set item(value: Item) {
+	set item(value: CanUndef<Item>) {
 		this.field.set('itemStore', value);
 	}
 

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
@@ -46,7 +46,13 @@ export default class bFunctionalGettersDummy extends bDummy {
 	@computed({cache: false})
 	get isValueCached(): boolean {
 		// eslint-disable-next-line @v4fire/unbound-method
-		return cacheStatus in (Object.getOwnPropertyDescriptor(this, 'value')?.get ?? {});
+		const {get} = Object.getOwnPropertyDescriptor(this, 'value')!;
+
+		if (get == null) {
+			throw new TypeError('"value" getter is missing');
+		}
+
+		return cacheStatus in get;
 	}
 
 	@hook(['beforeDestroy', 'mounted'])

--- a/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy.ts
@@ -8,7 +8,9 @@
 
 /* eslint-disable @v4fire/require-jsdoc */
 
-import bDummy, { component, system, computed } from 'components/dummies/b-dummy/b-dummy';
+import { cacheStatus } from 'core/component/watch';
+
+import bDummy, { component, system, computed, hook } from 'components/dummies/b-dummy/b-dummy';
 import type { Item } from 'core/component/functional/test/b-functional-getters-dummy/interface';
 
 import { item } from 'core/component/functional/test/b-functional-getters-dummy/const';
@@ -19,6 +21,9 @@ export * from 'components/dummies/b-dummy/b-dummy';
 export default class bFunctionalGettersDummy extends bDummy {
 	@system()
 	itemStore?: CanUndef<Item>;
+
+	@system({merge: true})
+	logStore: string[] = [];
 
 	protected override $refs!: bDummy['$refs'] & {
 		container: HTMLElement;
@@ -38,8 +43,18 @@ export default class bFunctionalGettersDummy extends bDummy {
 		this.field.set('itemStore', value);
 	}
 
+	@computed({cache: false})
+	get isValueCached(): boolean {
+		// eslint-disable-next-line @v4fire/unbound-method
+		return cacheStatus in (Object.getOwnPropertyDescriptor(this, 'value')?.get ?? {});
+	}
+
+	@hook(['beforeDestroy', 'mounted'])
+	logValueIsCached(): void {
+		this.logStore.push(`Hook: ${this.hook}. Value is cached: ${this.isValueCached}`);
+	}
+
 	mounted(): void {
-		this.console.log('mounted');
 		this.item = item;
 		this.$refs.container.textContent = this.value;
 	}

--- a/src/core/component/functional/test/b-functional-getters-dummy/const.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/const.ts
@@ -6,9 +6,4 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-package('b-functional-dummy')
-	.extends('b-dummy')
-	.dependencies(
-		'b-functional-button-dummy',
-		'b-functional-getters-dummy'
-	);
+export const item = {value: 3.14};

--- a/src/core/component/functional/test/b-functional-getters-dummy/index.js
+++ b/src/core/component/functional/test/b-functional-getters-dummy/index.js
@@ -6,9 +6,5 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-package('b-functional-dummy')
-	.extends('b-dummy')
-	.dependencies(
-		'b-functional-button-dummy',
-		'b-functional-getters-dummy'
-	);
+package('b-functional-getters-dummy')
+	.extends('b-dummy');

--- a/src/core/component/functional/test/b-functional-getters-dummy/interface.ts
+++ b/src/core/component/functional/test/b-functional-getters-dummy/interface.ts
@@ -6,9 +6,6 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-package('b-functional-dummy')
-	.extends('b-dummy')
-	.dependencies(
-		'b-functional-button-dummy',
-		'b-functional-getters-dummy'
-	);
+export interface Item {
+	value: number;
+}

--- a/src/core/component/functional/test/unit/getters.ts
+++ b/src/core/component/functional/test/unit/getters.ts
@@ -1,0 +1,44 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+import type { JSHandle, Locator } from 'playwright';
+
+import test from 'tests/config/unit/test';
+import { Component } from 'tests/helpers';
+
+import type bFunctionalDummy from 'core/component/functional/test/b-functional-dummy/b-functional-dummy';
+import type bFunctionalGettersDummy from 'core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy';
+
+test.describe('functional component getters', () => {
+	let
+		target: JSHandle<bFunctionalDummy>,
+		dummy: JSHandle<bFunctionalGettersDummy>,
+		text: Locator;
+
+	test.beforeEach(async ({demoPage, page}) => {
+		await demoPage.goto();
+
+		await Promise.all([
+			Component.waitForComponentTemplate(page, 'b-functional-dummy'),
+			Component.waitForComponentTemplate(page, 'b-functional-button-dummy')
+		]);
+
+		target = await Component.createComponent<bFunctionalDummy>(page, 'b-functional-dummy', {stage: 'getters'});
+		text = page.getByText(/Value/);
+		dummy = await target.evaluateHandle((ctx) => ctx.unsafe.$refs.gettersDummy!);
+	});
+
+	test.describe('on re-create', () => {
+		test('should reset getters cache', async () => {
+			// TODO: improve test clarity
+			await test.expect(text).toHaveText('Value: 3.14');
+			await target.evaluate((ctx) => ctx.counter++);
+			await test.expect(text).toHaveText('Value: 3.14');
+		});
+	});
+});

--- a/src/core/component/functional/test/unit/getters.ts
+++ b/src/core/component/functional/test/unit/getters.ts
@@ -12,12 +12,10 @@ import test from 'tests/config/unit/test';
 import { Component } from 'tests/helpers';
 
 import type bFunctionalDummy from 'core/component/functional/test/b-functional-dummy/b-functional-dummy';
-import type bFunctionalGettersDummy from 'core/component/functional/test/b-functional-getters-dummy/b-functional-getters-dummy';
 
 test.describe('functional component getters', () => {
 	let
 		target: JSHandle<bFunctionalDummy>,
-		dummy: JSHandle<bFunctionalGettersDummy>,
 		text: Locator;
 
 	test.beforeEach(async ({demoPage, page}) => {
@@ -30,15 +28,19 @@ test.describe('functional component getters', () => {
 
 		target = await Component.createComponent<bFunctionalDummy>(page, 'b-functional-dummy', {stage: 'getters'});
 		text = page.getByText(/Value/);
-		dummy = await target.evaluateHandle((ctx) => ctx.unsafe.$refs.gettersDummy!);
 	});
 
-	test.describe('on re-create', () => {
-		test('should reset getters cache', async () => {
-			// TODO: improve test clarity
-			await test.expect(text).toHaveText('Value: 3.14');
-			await target.evaluate((ctx) => ctx.counter++);
-			await test.expect(text).toHaveText('Value: 3.14');
-		});
+	test('should not be cached during the render', async () => {
+		await test.expect(text).toHaveText('Value: 3.14');
+		await target.evaluate((ctx) => ctx.counter++);
+		await test.expect(text).toHaveText('Value: 3.14');
+
+		const log = await target.evaluate((ctx) => ctx.unsafe.$refs.gettersDummy!.logStore);
+
+		test.expect(log).toEqual([
+			'Hook: mounted. Value is cached: false',
+			'Hook: beforeDestroy. Value is cached: true',
+			'Hook: mounted. Value is cached: false'
+		]);
 	});
 });

--- a/src/core/component/functional/test/unit/main.ts
+++ b/src/core/component/functional/test/unit/main.ts
@@ -35,10 +35,10 @@ test.describe('functional component', () => {
 	test.describe('on parent re-render', () => {
 		test('should have valid event handlers', async () => {
 			await clickAndWaitForEvent();
-			await test.expect(text).toHaveText('Click count: 0');
+			await test.expect(text).toHaveText('Counter: 0');
 
 			await target.evaluate((ctx) => ctx.syncStoreWithState());
-			await test.expect(text).toHaveText('Click count: 1');
+			await test.expect(text).toHaveText('Counter: 1');
 
 			await clickAndWaitForEvent();
 		});

--- a/src/core/component/functional/test/unit/main.ts
+++ b/src/core/component/functional/test/unit/main.ts
@@ -27,23 +27,17 @@ test.describe('functional component', () => {
 			Component.waitForComponentTemplate(page, 'b-functional-button-dummy')
 		]);
 
-		target = await Component.createComponent<bFunctionalDummy>(page, 'b-functional-dummy');
-		text = page.getByText(/Click count/);
+		target = await Component.createComponent<bFunctionalDummy>(page, 'b-functional-dummy', {stage: 'main'});
+		text = page.getByText(/Counter/);
 		button = page.getByRole('button');
 	});
 
 	test.describe('on parent re-render', () => {
 		test('should have valid event handlers', async () => {
-			const clickAndWaitForEvent = async () => {
-				const promise = target.evaluate((ctx) => ctx.unsafe.$refs.button.promisifyOnce('click:component'));
-				await button.click();
-				await test.expect(promise).toBeResolved();
-			};
-
 			await clickAndWaitForEvent();
 			await test.expect(text).toHaveText('Click count: 0');
 
-			await target.evaluate((ctx) => ctx.updateClickCountField());
+			await target.evaluate((ctx) => ctx.syncStoreWithState());
 			await test.expect(text).toHaveText('Click count: 1');
 
 			await clickAndWaitForEvent();
@@ -53,7 +47,7 @@ test.describe('functional component', () => {
 			await test.expect(clickAndGetCounts()).resolves.toEqual([1, 1]);
 
 			const clicks = await target.evaluate((ctx) => {
-				const {button} = ctx.unsafe.$refs;
+				const button = ctx.unsafe.$refs.button!;
 				button.unsafe.$destroy();
 
 				const {clickCount, uniqueClickCount} = button;
@@ -70,14 +64,20 @@ test.describe('functional component', () => {
 			await test.expect(clickAndGetCounts()).resolves.toEqual([1, 1]);
 			await test.expect(clickAndGetCounts()).resolves.toEqual([2, 2]);
 
-			await target.evaluate((ctx) => ctx.updateClickCountField());
+			await target.evaluate((ctx) => ctx.syncStoreWithState());
 			await test.expect(clickAndGetCounts()).resolves.toEqual([3, 1]);
 		});
+
+		async function clickAndWaitForEvent() {
+			const promise = target.evaluate((ctx) => ctx.unsafe.$refs.button!.promisifyOnce('click:component'));
+			await button.click();
+			await test.expect(promise).toBeResolved();
+		}
 
 		async function clickAndGetCounts() {
 			await button.click();
 			return target.evaluate((ctx) => {
-				const {clickCount, uniqueClickCount} = ctx.unsafe.$refs.button;
+				const {clickCount, uniqueClickCount} = ctx.unsafe.$refs.button!;
 				return [clickCount, uniqueClickCount];
 			});
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5517,7 +5517,7 @@ __metadata:
     webpack: "npm:5.82.1"
     webpack-cli: "npm:5.0.1"
   peerDependencies:
-    "@v4fire/core": ^4.0.0-alpha.34
+    "@v4fire/core": ^4.0.0-alpha.37
     webpack: ^5.82.1
   dependenciesMeta:
     "@pzlr/build-core":


### PR DESCRIPTION
Ключевое изменение в src/core/component/accessor/index.ts.
Теперь для функциональных компонентов значения computed getter'ов не сохраняются в кэш во время рендера.