### PR TITLE
fix(core/component/render): modify vnode patch flags before its creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-07-??)
+
+#### :bug: Bug Fix
+
+* Fixed incorrect patchFlag when creating vnode with event handler `core/component/render`
+
 ## v4.0.0-beta.106 (2024-06-25)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* Fixed incorrect patchFlag when creating vnode with event handler `core/component/render`
+* Fixed incorrect `patchFlag` when creating vnode with event handler `core/component/render`
 
 ## v4.0.0-beta.106 (2024-06-25)
 

--- a/components-lock.json
+++ b/components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "56c4940e4f7a7e13a5d557ef79d87d4abeb6dee36e79e043ee1919a9a53e38b5",
+  "hash": "410c0b21f66077394343e6d7f20906dcbc8cfa9c493d1774f765acd4553cbc03",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -148,6 +148,38 @@
             "src/core/component/interface/component/test/b-component-interface-dummy/b-component-interface-dummy.styl"
           ],
           "tpl": "src/core/component/interface/component/test/b-component-interface-dummy/b-component-interface-dummy.ss",
+          "etpl": null
+        }
+      ],
+      [
+        "b-component-render-flags-dummy",
+        {
+          "index": "src/core/component/render/helpers/test/b-component-render-flags-dummy/index.js",
+          "declaration": {
+            "name": "b-component-render-flags-dummy",
+            "parent": "i-block",
+            "dependencies": [],
+            "libs": []
+          },
+          "name": "b-component-render-flags-dummy",
+          "parent": "i-block",
+          "dependencies": [],
+          "libs": [],
+          "resolvedLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "resolvedOwnLibs": {
+            "%data": "%data:Set",
+            "%data:Set": []
+          },
+          "type": "block",
+          "mixin": false,
+          "logic": "src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ts",
+          "styles": [
+            "src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.styl"
+          ],
+          "tpl": "src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ss",
           "etpl": null
         }
       ],

--- a/src/core/component/render/CHANGELOG.md
+++ b/src/core/component/render/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :bug: Bug Fix
 
-* Fixed incorrect patchFlag when creating vnode with event handler
+* Fixed incorrect `patchFlag` when creating vnode with event handler
 
 ## v4.0.0-beta.82 (2024-04-02)
 

--- a/src/core/component/render/CHANGELOG.md
+++ b/src/core/component/render/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-07-??)
+
+#### :bug: Bug Fix
+
+* Fixed incorrect patchFlag when creating vnode with event handler
+
 ## v4.0.0-beta.82 (2024-04-02)
 
 #### :bug: Bug Fix

--- a/src/core/component/render/helpers/attrs.ts
+++ b/src/core/component/render/helpers/attrs.ts
@@ -11,7 +11,6 @@ import { evalWith } from 'core/json';
 import type { VNode } from 'core/component/engines';
 
 import { isHandler, mergeProps } from 'core/component/render/helpers/props';
-import { setVNodePatchFlags } from 'core/component/render/helpers/flags';
 
 import type { ComponentInterface } from 'core/component/interface';
 
@@ -98,8 +97,6 @@ export function resolveAttrs<T extends VNode>(this: ComponentInterface, vnode: T
 			key = 'data-has-v-on-directives';
 
 		if (props[key] != null) {
-			setVNodePatchFlags(vnode, 'props');
-
 			const dynamicProps = vnode.dynamicProps ?? [];
 			vnode.dynamicProps = dynamicProps;
 

--- a/src/core/component/render/helpers/flags.ts
+++ b/src/core/component/render/helpers/flags.ts
@@ -8,7 +8,7 @@
 
 import type { VNode, VNodeProps } from 'core/component/engines';
 
-const flagValues = {
+export const flagValues = {
 	classes: 2,
 	styles: 4,
 	props: 8,

--- a/src/core/component/render/helpers/flags.ts
+++ b/src/core/component/render/helpers/flags.ts
@@ -57,26 +57,23 @@ export function setVNodePatchFlags(vnode: VNode, ...flags: Flags): void {
 }
 
 /**
- * Creates patch flag using the initial value
+ * Returns the value of the `patchFlag` property based on the initial value and a set of individual flags
  *
- * @param initial - initial flag value
+ * @param initial - the initial value
  * @param flags - the flags to set
  */
-export function buildPatchFlag(
-	initial: number = 0,
-	...flags: PatchFlags
-): number {
+export function buildPatchFlag(initial: number = 0, ...flags: PatchFlags): number {
 	// eslint-disable-next-line no-bitwise
 	return flags.reduce((result, flag) => result | flagValues[flag], initial);
 }
 
 /**
- * Modifies the initial patchFlag if a vnode has special props
+ * Normalizes the initial `patchFlag` if a vnode has special props
  *
- * @param patchFlag - initial patchFlag
- * @param props - initial props
+ * @param patchFlag - the initial `patchFlag` value
+ * @param props - the initial vnode props
  */
-export function mutatePatchFlagUsingProps(
+export function normalizePatchFlagUsingProps(
 	patchFlag: number | undefined,
 	props: Nullable<Record<string, unknown> & VNodeProps>
 ): number {

--- a/src/core/component/render/helpers/index.ts
+++ b/src/core/component/render/helpers/index.ts
@@ -10,3 +10,7 @@ export * from 'core/component/render/helpers/normalizers';
 export * from 'core/component/render/helpers/props';
 export * from 'core/component/render/helpers/attrs';
 export * from 'core/component/render/helpers/flags';
+
+//#if runtime has dummyComponents
+import('core/component/render/helpers/test/b-component-render-flags-dummy');
+//#endif

--- a/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ss
+++ b/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ss
@@ -1,0 +1,16 @@
+- namespace [%fileName%]
+
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+- include 'components/super/i-block'|b as placeholder
+
+- template index() extends ['i-block'].index
+	- block body
+		< button @click = () => onClick() | -testid = vnode
+			+= self.slot()

--- a/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.styl
+++ b/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.styl
@@ -1,0 +1,15 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+@import "components/super/i-block/i-block.styl"
+
+$p = {
+
+}
+
+b-component-render-flags-dummy extends i-block

--- a/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ts
+++ b/src/core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy.ts
@@ -1,0 +1,27 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+/* eslint-disable @v4fire/require-jsdoc */
+import iBlock, { component, system } from 'components/super/i-block/i-block';
+
+export * from 'components/super/i-block/i-block';
+
+@component({
+	functional: {
+		functional: true
+	}
+})
+
+export default class bComponentRenderFlagsDummy extends iBlock {
+	@system()
+	clickCount: number = 0;
+
+	onClick(): void {
+		this.clickCount++;
+	}
+}

--- a/src/core/component/render/helpers/test/b-component-render-flags-dummy/index.js
+++ b/src/core/component/render/helpers/test/b-component-render-flags-dummy/index.js
@@ -1,0 +1,10 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+package('b-component-render-flags-dummy')
+	.extends('i-block');

--- a/src/core/component/render/helpers/test/unit/flags.ts
+++ b/src/core/component/render/helpers/test/unit/flags.ts
@@ -27,7 +27,7 @@ test.describe('core/component/render/helpers/flags', () => {
 
 	test('should add `props` to `patchFlag` if a node has an event handler', async ({page}) => {
 		await renderDummy(page);
-		const vnode = await page.getByTestId('vnode');
+		const vnode = page.getByTestId('vnode');
 		const patchFlag = await vnode.evaluate(
 			(ctx) => (<{__vnode?: VNode}>ctx).__vnode?.patchFlag ?? 0
 		);

--- a/src/core/component/render/helpers/test/unit/flags.ts
+++ b/src/core/component/render/helpers/test/unit/flags.ts
@@ -7,6 +7,7 @@
  */
 
 /* eslint-disable no-bitwise */
+
 import type { Page } from 'playwright';
 
 import test from 'tests/config/unit/test';
@@ -24,7 +25,7 @@ test.describe('core/component/render/helpers/flags', () => {
 		await Component.waitForComponentTemplate(page, 'b-component-render-flags-dummy');
 	});
 
-	test('should add "props" to patchFlag if a node has an event handler', async ({page}) => {
+	test('should add `props` to `patchFlag` if a node has an event handler', async ({page}) => {
 		await renderDummy(page);
 		const vnode = await page.getByTestId('vnode');
 		const patchFlag = await vnode.evaluate(
@@ -45,7 +46,7 @@ test.describe('core/component/render/helpers/flags', () => {
 		await target.update({});
 		await button.click();
 
-		// Get current context of the functional component from the DOM
+		// Get the current context of the functional component from the DOM
 		const clickCount = await page.locator('.b-component-render-flags-dummy')
 			.evaluate((ctx) => (<{component: bComponentRenderFlagsDummy} & HTMLElement>ctx).component.clickCount);
 

--- a/src/core/component/render/helpers/test/unit/flags.ts
+++ b/src/core/component/render/helpers/test/unit/flags.ts
@@ -1,0 +1,58 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+/* eslint-disable no-bitwise */
+import type { Page } from 'playwright';
+
+import test from 'tests/config/unit/test';
+
+import { Component } from 'tests/helpers';
+
+import type { VNode } from 'core/component/engines';
+import { flagValues } from 'core/component/render/helpers/flags';
+
+import type bComponentRenderFlagsDummy from 'core/component/render/helpers/test/b-component-render-flags-dummy/b-component-render-flags-dummy';
+
+test.describe('core/component/render/helpers/flags', () => {
+	test.beforeEach(async ({demoPage, page}) => {
+		await demoPage.goto();
+		await Component.waitForComponentTemplate(page, 'b-component-render-flags-dummy');
+	});
+
+	test('should add "props" to patchFlag if a node has an event handler', async ({page}) => {
+		await renderDummy(page);
+		const vnode = await page.getByTestId('vnode');
+		const patchFlag = await vnode.evaluate(
+			(ctx) => (<{__vnode?: VNode}>ctx).__vnode?.patchFlag ?? 0
+		);
+
+		test.expect(patchFlag & flagValues.props).toEqual(flagValues.props);
+	});
+
+	test('the event handler should be patched during the rerender', async ({page}) => {
+		const target = await Component.createComponentInDummy<bComponentRenderFlagsDummy>(
+			page, 'b-component-render-flags-dummy-functional', {}
+		);
+
+		const button = page.getByRole('button');
+
+		await button.click();
+		await target.update({});
+		await button.click();
+
+		// Get current context of the functional component from the DOM
+		const clickCount = await page.locator('.b-component-render-flags-dummy')
+			.evaluate((ctx) => (<{component: bComponentRenderFlagsDummy} & HTMLElement>ctx).component.clickCount);
+
+		test.expect(clickCount).toEqual(2);
+	});
+
+	async function renderDummy(page: Page) {
+		await Component.createComponent(page, 'b-component-render-flags-dummy');
+	}
+});

--- a/src/core/component/render/wrappers.ts
+++ b/src/core/component/render/wrappers.ts
@@ -46,6 +46,7 @@ import {
 	isHandler,
 
 	resolveAttrs,
+	mutatePatchFlagUsingProps,
 	normalizeComponentAttrs,
 
 	setVNodePatchFlags,
@@ -69,6 +70,7 @@ export function wrapCreateVNode<T extends typeof createVNode>(original: T): T {
  */
 export function wrapCreateElementVNode<T extends typeof createElementVNode>(original: T): T {
 	return Object.cast(function createElementVNode(this: ComponentInterface, ...args: Parameters<T>) {
+		args[3] = mutatePatchFlagUsingProps(args[3], args[1]);
 		return resolveAttrs.call(this, original.apply(null, args));
 	});
 }
@@ -84,6 +86,8 @@ export function wrapCreateBlock<T extends typeof createBlock>(original: T): T {
 
 		let
 			component: CanNull<ComponentMeta> = null;
+
+		patchFlag = mutatePatchFlagUsingProps(patchFlag, attrs);
 
 		if (Object.isString(name)) {
 			component = registerComponent(name);
@@ -236,6 +240,7 @@ export function wrapCreateBlock<T extends typeof createBlock>(original: T): T {
  */
 export function wrapCreateElementBlock<T extends typeof createElementBlock>(original: T): T {
 	return Object.cast(function createElementBlock(this: ComponentInterface, ...args: Parameters<T>) {
+		args[3] = mutatePatchFlagUsingProps(args[3], args[1]);
 		return resolveAttrs.call(this, original.apply(null, args));
 	});
 }

--- a/src/core/component/render/wrappers.ts
+++ b/src/core/component/render/wrappers.ts
@@ -46,7 +46,7 @@ import {
 	isHandler,
 
 	resolveAttrs,
-	mutatePatchFlagUsingProps,
+	normalizePatchFlagUsingProps,
 	normalizeComponentAttrs,
 
 	setVNodePatchFlags,
@@ -70,7 +70,7 @@ export function wrapCreateVNode<T extends typeof createVNode>(original: T): T {
  */
 export function wrapCreateElementVNode<T extends typeof createElementVNode>(original: T): T {
 	return Object.cast(function createElementVNode(this: ComponentInterface, ...args: Parameters<T>) {
-		args[3] = mutatePatchFlagUsingProps(args[3], args[1]);
+		args[3] = normalizePatchFlagUsingProps(args[3], args[1]);
 		return resolveAttrs.call(this, original.apply(null, args));
 	});
 }
@@ -87,7 +87,7 @@ export function wrapCreateBlock<T extends typeof createBlock>(original: T): T {
 		let
 			component: CanNull<ComponentMeta> = null;
 
-		patchFlag = mutatePatchFlagUsingProps(patchFlag, attrs);
+		patchFlag = normalizePatchFlagUsingProps(patchFlag, attrs);
 
 		if (Object.isString(name)) {
 			component = registerComponent(name);
@@ -240,7 +240,7 @@ export function wrapCreateBlock<T extends typeof createBlock>(original: T): T {
  */
 export function wrapCreateElementBlock<T extends typeof createElementBlock>(original: T): T {
 	return Object.cast(function createElementBlock(this: ComponentInterface, ...args: Parameters<T>) {
-		args[3] = mutatePatchFlagUsingProps(args[3], args[1]);
+		args[3] = normalizePatchFlagUsingProps(args[3], args[1]);
 		return resolveAttrs.call(this, original.apply(null, args));
 	});
 }


### PR DESCRIPTION
If a vnode has special attributes, its patch flag must be modified before the original vnode creation function is called. This ensures that Vue will correctly initialize the vnode