### PR TITLE
Add a `rootContent` wrapper block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.??? (2024-??-??)
+
+#### :house: Internal
+
+* Added a new `rootContent` layout wrapper block `components/super/i-block`
+
 ## v4.0.0-beta.111 (2024-07-18)
 
 #### :house: Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :house: Internal
 
-* Added a new `rootContent` layout wrapper block `components/super/i-block`
+* Added a new `rootContent` layout wrapper block `iBlock`
 
 ## v4.0.0-beta.111 (2024-07-18)
 

--- a/src/components/super/i-block/CHANGELOG.md
+++ b/src/components/super/i-block/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## 4.0.0-beta.?? (2024-??-??)
+
+#### :house: Internal
+
+* Added a new `rootContent` layout wrapper block
+
 ## 4.0.0-beta.108.a-new-hope (2024-07-15)
 
 #### :rocket: New Feature

--- a/src/components/super/i-block/CHANGELOG.md
+++ b/src/components/super/i-block/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## 4.0.0-beta.?? (2024-??-??)
+## v4.0.0-beta.??? (2024-??-??)
 
 #### :house: Internal
 

--- a/src/components/super/i-block/i-block.ss
+++ b/src/components/super/i-block/i-block.ss
@@ -303,14 +303,15 @@
 
 								- block bodyFooter
 
-						- block skeleton
+						- block rootContent
+							- block skeleton
 
-						- if SSR || HYDRATION
-							< template v-if = ssrRendering
+							- if SSR || HYDRATION
+								< template v-if = ssrRendering
+									+= self.renderRootContent()
+
+							- else
 								+= self.renderRootContent()
-
-						- else
-							+= self.renderRootContent()
 
 - template mono() extends ['i-block'].index
 	- renderMode = 'mono'


### PR DESCRIPTION
Добавление блока-обёртки для контента. Продиктовано необходимостью возможности отрисовать элемент/компонент при SSR в случае, когда рендеринг основного содержимого запрещён через проп `ssrRendering`. Ранее в отдельный блок были выделены скелетоны, но рациональнее иметь общую обёртку на такой случай.