### PR TITLE
fix: add p.source external check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.74.4 (2024-08-02)
+
+#### :nail_care: Polish
+
+* Now, if an external link is passed to `initLibs()`, `PUBLIC_PATH` won't be added to it.
+
 ## v3.74.3 (2024-07-18)
 
 #### :house: Internal

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/index.js",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "3.74.3",
+  "version": "3.74.4",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/super/i-static-page/CHANGELOG.md
+++ b/src/super/i-static-page/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.74.4 (2024-08-02)
+
+#### :nail_care: Polish
+
+* Now, if an external link is passed to `initLibs()`, `PUBLIC_PATH` won't be added to it.
+
 ## v3.72.0 (2024-04-25)
 
 #### 🚀 New Feature

--- a/src/super/i-static-page/README.md
+++ b/src/super/i-static-page/README.md
@@ -260,6 +260,7 @@ const deps = {
  *   1. `lib` - external library, i.e, something from `node_modules`
  *   2. `src` - internal resource, i.e, something that builds from the `/src` folder
  *   3. `output` - output library, i.e, something that builds to the `/dist/client` folder
+ *   4. `external` - externally hosted library, i.e. from a CDN
  *
  * @typedef {('lib'|'src'|'output')}
  */

--- a/src/super/i-static-page/modules/ss-helpers/libs.js
+++ b/src/super/i-static-page/modules/ss-helpers/libs.js
@@ -176,7 +176,7 @@ async function initLibs(libs, assets) {
 				await delay((1).second());
 			}
 
-		} else {
+		} else if (p.source !== 'external') {
 			p.src = addPublicPath(p.src);
 		}
 


### PR DESCRIPTION
`addPublicPath` внутри проверяет на `webpack.dynamicPublicPath()`. Если последнее `true`, то возвращается js-код с PUBLIC_PATH в качестве link href даже для внешних ссылок, что не есть ожидаемое поведение