### PR TITLE
fix(b-router/modules/transition): fix promises collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-08-??)
+
+#### :bug: Bug Fix
+
+* Added `join: 'replace'` for router transitions. It allows to avoid collisions during calls of `push` and `replace` `b-router`
+
 ## v4.0.0-beta.117 (2024-07-31)
 
 #### :house: Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
-## v4.0.0-beta.?? (2024-08-??)
+## v4.0.0-beta.118 (2024-08-01)
 
 #### :bug: Bug Fix
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "yarn@4.0.2",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "4.0.0-beta.117",
+  "version": "4.0.0-beta.118",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/components/base/b-router/CHANGELOG.md
+++ b/src/components/base/b-router/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v4.0.0-beta.?? (2024-08-??)
+## v4.0.0-beta.118 (2024-08-01)
 
 #### :bug: Bug Fix
 

--- a/src/components/base/b-router/CHANGELOG.md
+++ b/src/components/base/b-router/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-08-??)
+
+#### :bug: Bug Fix
+
+* Added `join: 'replace'` for router transitions. It allows to avoid collisions during calls of `push` and `replace`
+
 ## v4.0.0-beta.112 (2024-07-22)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-router/modules/transition/class.ts
+++ b/src/components/base/b-router/modules/transition/class.ts
@@ -8,6 +8,8 @@
 
 import symbolGenerator from 'core/symbol';
 
+import type { AsyncPromiseOptions } from 'core/async';
+
 import * as router from 'core/router';
 import type { Router } from 'core/router/interface';
 
@@ -20,8 +22,9 @@ import type { TransitionContext } from 'components/base/b-router/modules/transit
 const
 	$$ = symbolGenerator();
 
-const transitionLabel = {
-	label: $$.transition
+const transitionOptions: AsyncPromiseOptions = {
+	label: $$.transition,
+	join: 'replace'
 };
 
 export default class Transition {
@@ -156,13 +159,13 @@ export default class Transition {
 		this.initNewRouteInfo();
 
 		this.scroll.createSnapshot();
-		await $a.promise(this.scroll.updateCurrentRouteScroll(), transitionLabel);
+		await $a.promise(this.scroll.updateCurrentRouteScroll(), transitionOptions);
 
 		// We didn't find any route matching the given ref
 		if (this.newRouteInfo == null) {
 			// The transition was user-generated, then we need to save the scroll
 			if (!SSR && this.method !== 'event' && this.ref != null) {
-				await $a.promise(engine[this.method](this.ref, this.scroll.getSnapshot()), transitionLabel);
+				await $a.promise(engine[this.method](this.ref, this.scroll.getSnapshot()), transitionOptions);
 			}
 
 			return;
@@ -268,7 +271,7 @@ export default class Transition {
 				return;
 			}
 
-			await $a.promise(engine[this.method](newRoute.url, plainInfo), transitionLabel).then(() => {
+			await $a.promise(engine[this.method](newRoute.url, plainInfo), transitionOptions).then(() => {
 				const isSoftTransition = r.route != null && Object.fastCompare(
 					router.convertRouteToPlainObjectWithoutProto(currentRoute),
 					router.convertRouteToPlainObjectWithoutProto(newRoute)


### PR DESCRIPTION
В этом [коммите](https://github.com/V4Fire/Client/commit/91565b0b03b9dcf8ed31cc7984cba4bfb5c9a4d3#diff-a893b891296f4b543669b02282d884c013e14e9603aec82ee1b831ea0a7d5d25L160) добавилось оборачивание метода обновления скролла страницы в `async.promise`, из-за чего стала стрелять ошибка при создании самого первого перехода на страницу в [этом месте](https://github.com/V4Fire/Client/blob/v4/src/components/base/b-router/modules/transition/class.ts#L271)

Добавил в параметры для `async.promise` `join: 'replace'`

<img width="692" alt="Screenshot 2024-07-31 at 5 48 40 PM" src="https://github.com/user-attachments/assets/f9d3f1c8-8098-4f86-be0c-0c81264c6ba5">