### PR TITLE
fix: do not wait for external library to appear in filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.??.? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed an implicitly infinite loop when we tried to wait for externally hosted library to appear in the filesystem.
+
 ## v3.74.6 (2024-08-02)
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
-## v3.??.? (2024-??-??)
+## v3.74.7 (2024-08-29)
 
 #### :bug: Bug Fix
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/core/index.js",
   "typings": "index.d.ts",
   "license": "MIT",
-  "version": "3.74.6",
+  "version": "3.74.7",
   "author": {
     "name": "kobezzza",
     "email": "kobezzza@gmail.com",

--- a/src/super/i-static-page/CHANGELOG.md
+++ b/src/super/i-static-page/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v3.??.? (2024-??-??)
+## v3.74.7 (2024-08-29)
 
 #### :bug: Bug Fix
 

--- a/src/super/i-static-page/CHANGELOG.md
+++ b/src/super/i-static-page/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v3.??.? (2024-??-??)
+
+#### :bug: Bug Fix
+
+* Fixed an implicitly infinite loop when we tried to wait for externally hosted library to appear in the filesystem.
+
 ## v3.74.4 (2024-08-02)
 
 #### :nail_care: Polish

--- a/src/super/i-static-page/modules/ss-helpers/libs.js
+++ b/src/super/i-static-page/modules/ss-helpers/libs.js
@@ -171,13 +171,15 @@ async function initLibs(libs, assets) {
 			p.src = resolveAsLib({name: key, relative: !p.inline}, cwd, p.src);
 		}
 
-		if (p.inline) {
-			while (!fs.existsSync(p.src)) {
-				await delay((1).second());
-			}
+		if (p.source !== 'external') {
+			if (p.inline) {
+				while (!fs.existsSync(p.src)) {
+					await delay((1).second());
+				}
 
-		} else if (p.source !== 'external') {
-			p.src = addPublicPath(p.src);
+			} else {
+				p.src = addPublicPath(p.src);
+			}
 		}
 
 		res.push(p);


### PR DESCRIPTION
Fixed an implicitly infinite loop when we tried to wait for external (that means it is externally-hosted) library to appear in filesystem