### PR TITLE
Fix/page meta data xss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v3.74.8 (2024-09-17)
+
+#### :bug: Bug Fix
+
+* Fixed setting `document.title` to avoid potential XSS `PageMetaData`
+
 ## v3.74.7 (2024-08-29)
 
 #### :bug: Bug Fix

--- a/src/super/i-static-page/modules/page-meta-data/CHANGELOG.md
+++ b/src/super/i-static-page/modules/page-meta-data/CHANGELOG.md
@@ -8,3 +8,9 @@ Changelog
 > - :memo:       [Documentation]
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
+
+## v3.74.8 (2024-09-17)
+
+#### :bug: Bug Fix
+
+* Fixed setting `document.title` to avoid potential XSS `PageMetaData`

--- a/src/super/i-static-page/modules/page-meta-data/index.ts
+++ b/src/super/i-static-page/modules/page-meta-data/index.ts
@@ -26,13 +26,7 @@ export default class PageMetaData {
 	 * @param value - new title value
 	 */
 	set title(value: string) {
-		const
-			div = Object.assign(document.createElement('div'), {innerHTML: value}),
-			title = div.textContent ?? '';
-
-		// Fix strange Chrome bug
-		document.title = `${title} `;
-		document.title = title;
+		document.title = value;
 	}
 
 	/**


### PR DESCRIPTION
Переехал на метод установки `document.title` как в v4v4 (https://github.com/V4Fire/Client/blob/v4/src/core/page-meta-data/elements/title/engines/dom/index.ts#L14), чтобы избежать xss при создании тега. 