### PR TITLE
fix(i-block): apply async.proxy for the global event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## 4.0.0-beta.?? (2024-09-??)
+
+#### :bug: Bug Fix
+
+* Fix the bug when the global event listener might be called after the component has been destroyed `iBlock`
+
+
 ## 4.0.0-beta.136 (2024-09-17)
 
 #### :house: Internal

--- a/src/components/super/i-block/CHANGELOG.md
+++ b/src/components/super/i-block/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-09-??)
+
+#### :bug: Bug Fix
+
+* Fix the bug when the global event listener might be called after the component has been destroyed
+
 ## v4.0.0-beta.117 (2024-07-31)
 
 #### :house: Internal

--- a/src/components/super/i-block/modules/listeners/index.ts
+++ b/src/components/super/i-block/modules/listeners/index.ts
@@ -97,6 +97,7 @@ export function initGlobalListeners(component: iBlock, resetListener?: boolean):
 
 	function waitNextTickForReset(rawFn: () => CanPromise<void>) {
 		const fn = $a.proxy(rawFn);
+
 		return async () => {
 			try {
 				await ctx.nextTick({label: $$.reset});

--- a/src/components/super/i-block/modules/listeners/index.ts
+++ b/src/components/super/i-block/modules/listeners/index.ts
@@ -36,6 +36,7 @@ export function initGlobalListeners(component: iBlock, resetListener?: boolean):
 		ctx = component.unsafe;
 
 	const {
+		async: $a,
 		globalName,
 		globalEmitter: $e,
 		state: $s,
@@ -94,7 +95,8 @@ export function initGlobalListeners(component: iBlock, resetListener?: boolean):
 		await ctx.reload();
 	}));
 
-	function waitNextTickForReset(fn: Function) {
+	function waitNextTickForReset(rawFn: () => CanPromise<void>) {
+		const fn = $a.proxy(rawFn);
 		return async () => {
 			try {
 				await ctx.nextTick({label: $$.reset});

--- a/src/components/super/i-block/test/unit/listeners.ts
+++ b/src/components/super/i-block/test/unit/listeners.ts
@@ -1,0 +1,54 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+import type { JSHandle } from 'playwright';
+import test from 'tests/config/unit/test';
+
+import { Component } from 'tests/helpers';
+import { createSpy, SpyObject } from 'tests/helpers/mock';
+
+import type iBlock from 'components/super/i-block/i-block';
+
+test.describe('<i-block> global listeners', () => {
+	let dummy: JSHandle<iBlock>;
+	let reloadSpy: SpyObject;
+
+	test.beforeEach(async ({demoPage, page}) => {
+		await demoPage.goto();
+		dummy = await Component.createComponent(page, 'b-dummy');
+		reloadSpy = await createSpy(dummy, (ctx) => jestMock.spy(ctx, 'reload'));
+
+		// @ts-ignore (unsafe)
+		await dummy.evaluate((ctx) => ctx.initGlobalEvents(true));
+	});
+
+	test('the reload method should be invoked on the next tick following the emission of the `reset.load.silence` event', async () => {
+		await dummy.evaluate((ctx) => ctx.unsafe.globalEmitter.emit('reset.load.silence'));
+		await dummy.evaluate((ctx) => ctx.nextTick());
+		await test.expect(reloadSpy.callsCount).toBeResolvedTo(1);
+	});
+
+	test([
+		'the reload method should not be invoked on the next tick after the `reset.load.silence` event is emitted',
+		'if the component has been destroyed'
+	].join(' '), async () => {
+		const nextTick = dummy.evaluate((ctx) => ctx.nextTick());
+
+		await dummy.evaluate((ctx) => {
+			ctx.unsafe.globalEmitter.emit('reset.load.silence');
+
+			// Using a callback to synchronously destroy the component
+			ctx.nextTick(() => {
+				ctx.unsafe.$destroy();
+			});
+		});
+
+		await nextTick;
+		await test.expect(reloadSpy.callsCount).toBeResolvedTo(0);
+	});
+});


### PR DESCRIPTION
It fixes the bug when the listener might be called after the component has been destroyed