### PR TITLE
fix(core/component/decorators): override component name in meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-10-??)
+
+#### :bug: Bug Fix
+
+* Override a component name in the shared meta `core/component/decorators`
+
 ## v4.0.0-beta.143 (2024-10-09)
 
 #### :rocket: New Feature

--- a/src/core/component/decorators/CHANGELOG.md
+++ b/src/core/component/decorators/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-10-??)
+
+#### :bug: Bug Fix
+
+* Override a component name in the shared meta
+
 ## v4.0.0-beta.138.dsl-speedup (2024-10-01)
 
 #### :rocket: New Feature

--- a/src/core/component/decorators/component/index.ts
+++ b/src/core/component/decorators/component/index.ts
@@ -172,8 +172,17 @@ export function component(opts?: ComponentOptions): Function {
 						enumerable: true,
 						writable: true,
 						value: componentInfo.params
+					},
+
+					name: {
+						configurable: true,
+						enumerable: true,
+						writable: true,
+						value: componentInfo.name
 					}
 				});
+
+				rawMeta!.component.name = componentInfo.name;
 
 				if (rawMeta != null && componentInfo.parentMeta != null) {
 					inheritParams(rawMeta, componentInfo.parentMeta);

--- a/src/core/component/decorators/component/index.ts
+++ b/src/core/component/decorators/component/index.ts
@@ -179,10 +179,22 @@ export function component(opts?: ComponentOptions): Function {
 						enumerable: true,
 						writable: true,
 						value: componentInfo.name
+					},
+
+					component: {
+						configurable: true,
+						enumerable: true,
+						writable: true,
+						value: Object.create(rawMeta.component, {
+							name: {
+								configurable: true,
+								enumerable: true,
+								writable: true,
+								value: componentInfo.name
+							}
+						})
 					}
 				});
-
-				rawMeta!.component.name = componentInfo.name;
 
 				if (rawMeta != null && componentInfo.parentMeta != null) {
 					inheritParams(rawMeta, componentInfo.parentMeta);


### PR DESCRIPTION
closes #1446