### PR TITLE
fix(b-dynamic-page): avoid undefined page rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-10-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue with the comment node in `$refs` that occurs when rendering an `undefined` page `component/base/b-dynamic-page`
+
 ## v4.0.0-beta.144 (2024-10-09)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-dynamic-page/CHANGELOG.md
+++ b/src/components/base/b-dynamic-page/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-10-??)
+
+#### :bug: Bug Fix
+
+* Fixed an issue with the comment node in `$refs` that occurs when rendering an `undefined` page
+
 ## v4.0.0-beta.126 (2024-08-23)
 
 #### :rocket: New Feature

--- a/src/components/base/b-dynamic-page/b-dynamic-page.ss
+++ b/src/components/base/b-dynamic-page/b-dynamic-page.ss
@@ -26,7 +26,7 @@
 
 		< template v-for = el in asyncRender.iterate(renderIterator, {filter: renderFilter, group: registerRenderGroup})
 			< component.&__component &
-				v-if = !pageTakenFromCache |
+				v-if = !pageTakenFromCache && page != null |
 				ref = component |
 
 				:is = page |

--- a/src/components/base/b-dynamic-page/b-dynamic-page.ts
+++ b/src/components/base/b-dynamic-page/b-dynamic-page.ts
@@ -453,7 +453,7 @@ export default class bDynamicPage extends iDynamicPage {
 				// the `onPageChange` callback, which is why we must clean it up here.
 				that.onPageChange = undefined;
 
-				resolve(true);
+				resolve(newPage != null);
 			};
 		}
 	}

--- a/src/components/base/b-dynamic-page/test/unit/main.ts
+++ b/src/components/base/b-dynamic-page/test/unit/main.ts
@@ -147,4 +147,17 @@ test.describe('<b-dynamic-page>', () => {
 		]);
 	});
 
+	test('should not render an empty node if the page is `undefined`', async ({page}) => {
+		const target = await renderDynamicPage(page);
+
+		await target.evaluate((ctx) => {
+			ctx.page = undefined;
+
+			return ctx.$nextTick();
+		});
+
+		const componentInnerHtml = await target.evaluate((ctx) => ctx.unsafe.$el?.innerHTML);
+
+		await test.expect(componentInnerHtml).toBe('');
+	});
 });


### PR DESCRIPTION
Здесь была проблема с тем, что у нас устанавливался `page = undefined`, следовательно после рендера вставлялся узел комментария, который попадал в $refs. Это вызывало проблему того, что мы в $refs.component ожидаем инстанс компонента, а получаем дом узел