### PR TITLE
Исправление рендера вложенных чанков в SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
-## v4.0.0-beta.147 (2024-10-21)
+## v4.0.0-beta.?? (2024-11-??)
 
 #### :rocket: New Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.147 (2024-10-21)
+
+#### :rocket: New Feature
+
+* Add `SSRBuffer` and `SSRBufferItem` types `core/component/engines`
+
+#### :bug: Bug Fix
+
+* Updated the input parameter type to clarify that the function can handle not only VNodes but also buffers `core/component/directives/render`
+
+* Fixed the buffer rendering on server-side: it now correctly processes not only strings and promises but also nested buffers, as [dictated by Vue](https://github.com/vuejs/core/blob/main/packages/server-renderer/src/render.ts#L61-L65) `core/component/directives/render`
+
 ## v4.0.0-beta.146 (2024-10-18)
 
 #### :bug: Bug Fix

--- a/src/core/component/directives/render/CHANGELOG.md
+++ b/src/core/component/directives/render/CHANGELOG.md
@@ -9,6 +9,14 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.147 (2024-10-21)
+
+#### :bug: Bug Fix
+
+* Updated the input parameter type to clarify that the function can handle not only VNodes but also buffers
+
+* Fixed the buffer rendering on server-side: it now correctly processes not only strings and promises but also nested buffers, as [dictated by Vue](https://github.com/vuejs/core/blob/main/packages/server-renderer/src/render.ts#L61-L65)
+
 ## v4.0.0-beta.16 (2023-09-06)
 
 #### :bug: Bug Fix

--- a/src/core/component/directives/render/CHANGELOG.md
+++ b/src/core/component/directives/render/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v4.0.0-beta.147 (2024-10-21)
+## v4.0.0-beta.?? (2024-11-??)
 
 #### :bug: Bug Fix
 

--- a/src/core/component/directives/render/index.ts
+++ b/src/core/component/directives/render/index.ts
@@ -42,7 +42,7 @@ ComponentEngine.directive('render', {
 
 		if (Object.isString(vnode.type)) {
 			if (isSSRBufferItem(newVNode)) {
-				const children: Array<SSRBufferItem> = Array.toArray(newVNode);
+				const children: SSRBufferItem[] = Array.toArray(newVNode);
 
 				if (isTemplate) {
 					vnode.type = 'ssr-fragment';
@@ -106,7 +106,7 @@ ComponentEngine.directive('render', {
 		}
 
 		async function getSSRInnerHTML(content: CanArray<SSRBufferItem>) {
-			let normalizedContent: Array<SSRBufferItem> = Array.toArray(content);
+			let normalizedContent: SSRBufferItem[] = Array.toArray(content);
 
 			while (normalizedContent.some(isRecursiveBufferItem)) {
 				normalizedContent = (await Promise.all(normalizedContent)).flat();

--- a/src/core/component/directives/render/index.ts
+++ b/src/core/component/directives/render/index.ts
@@ -98,7 +98,7 @@ ComponentEngine.directive('render', {
 			}
 		}
 
-		function isRecursiveBufferItem(bufferItem: SSRBufferItem) {
+		function isRecursiveBufferItem(bufferItem: SSRBufferItem): bufferItem is Exclude<SSRBufferItem, string> {
 			return Object.isPromise(bufferItem) || Object.isArray(bufferItem);
 		}
 

--- a/src/core/component/directives/render/index.ts
+++ b/src/core/component/directives/render/index.ts
@@ -102,7 +102,7 @@ ComponentEngine.directive('render', {
 		}
 
 		function isAsyncVNode(VNode: CanPromise<VNode> | SSRBufferItem) {
-			return Object.isPromise(VNode) || (Object.isArray(VNode) && VNode.hasAsync);
+			return Object.isPromise(VNode) || Object.isArray(VNode);
 		}
 
 		async function getSSRInnerHTML(content: CanArray<SSRBufferItem>) {

--- a/src/core/component/directives/render/index.ts
+++ b/src/core/component/directives/render/index.ts
@@ -101,14 +101,14 @@ ComponentEngine.directive('render', {
 			return SSR;
 		}
 
-		function isAsyncVNode(VNode: CanPromise<VNode> | SSRBufferItem) {
-			return Object.isPromise(VNode) || Object.isArray(VNode);
+		function isRecursiveBufferItem(bufferItem: SSRBufferItem) {
+			return Object.isPromise(bufferItem) || Object.isArray(bufferItem);
 		}
 
 		async function getSSRInnerHTML(content: CanArray<SSRBufferItem>) {
 			let normalizedContent: Array<SSRBufferItem> = Array.toArray(content);
 
-			while (normalizedContent.some(isAsyncVNode)) {
+			while (normalizedContent.some(isRecursiveBufferItem)) {
 				normalizedContent = (await Promise.all(normalizedContent)).flat();
 			}
 

--- a/src/core/component/directives/render/interface.ts
+++ b/src/core/component/directives/render/interface.ts
@@ -6,6 +6,6 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-import type { DirectiveBinding, VNode } from 'core/component/engines';
+import type { DirectiveBinding, VNode, SSRBufferItem } from 'core/component/engines';
 
-export interface DirectiveParams extends DirectiveBinding<CanUndef<CanArray<VNode>>> {}
+export interface DirectiveParams extends DirectiveBinding<CanUndef<CanArray<VNode> | SSRBufferItem>> {}

--- a/src/core/component/engines/CHANGELOG.md
+++ b/src/core/component/engines/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v4.0.0-beta.147 (2024-10-21)
+## v4.0.0-beta.?? (2024-11-??)
 
 #### :rocket: New Feature
 

--- a/src/core/component/engines/CHANGELOG.md
+++ b/src/core/component/engines/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.147 (2024-10-21)
+
+#### :rocket: New Feature
+
+* Add `SSRBuffer` and `SSRBufferItem` types
+
 ## v4.0.0-alpha.1 (2022-12-14)
 
 #### :boom: Breaking Change

--- a/src/core/component/engines/interface.ts
+++ b/src/core/component/engines/interface.ts
@@ -78,3 +78,9 @@ export interface CreateAppFunction<E = Element> {
 		ResolveDirective<E>
 	>;
 }
+
+export type SSRBuffer = SSRBufferItem[] & {
+    hasAsync?: boolean;
+};
+
+export type SSRBufferItem = string | SSRBuffer | Promise<SSRBuffer>;


### PR DESCRIPTION
При серверном рендере учитывалось, что в массиве могут присутствовать асинхронные чанки, но не учитывалось, что могут быть вложенные массивы строк.

Вот тут указано, что в буфере могут быть строки, асинхронные буферы и рекурсивные массивы строк: https://github.com/vuejs/core/blob/main/packages/server-renderer/src/render.ts#L61-L65