### PR TITLE
fix(core/shims): import ssr shims only in SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-10-??)
+
+#### :house: Internal
+
+* Exclude SSR shims for non-SSR environments `core/shims`
+
 ## v4.0.0-beta.146 (2024-10-18)
 
 #### :bug: Bug Fix

--- a/src/core/shims/index.ts
+++ b/src/core/shims/index.ts
@@ -7,4 +7,6 @@
  */
 
 import 'core/shims/set-immediate';
+//#if runtime has ssr
 import 'core/shims/ssr';
+//#endif


### PR DESCRIPTION
Сейчас всегда используется полифилл для requestIdleCallback из core/shims/ssr. Этот PR исправляет это и использует полифилл из assets/lib/requestidlecallback.js