### PR TITLE
Fix/b list prev focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :bug: Bug Fix
 
-* Fixed the bug with previous active element not loosing its focus state `components/base/b-list`
+* Fixed the bug with previous active element not loosing its focus state `bList`
 
 ## v4.0.0-beta.146 (2024-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.147 (2024-10-25)
+
+#### :bug: Bug Fix
+
+* Fixed the bug with previous active element not loosing its focus state `components/base/b-list`
+
 ## v4.0.0-beta.146 (2024-10-18)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-list/CHANGELOG.md
+++ b/src/components/base/b-list/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.147 (2024-10-25)
+
+#### :bug: Bug Fix
+
+* Fixed the bug with previous active element not loosing its focus state
+
 ## v4.0.0-beta.26 (2023-09-20)
 
 #### :bug: Bug Fix

--- a/src/components/base/b-list/modules/helpers.ts
+++ b/src/components/base/b-list/modules/helpers.ts
@@ -24,6 +24,10 @@ export function setActiveMod(this: bList, el: Element, isActive: boolean): void 
 
 	this.block.setElementMod(el, 'link', 'active', isActive);
 
+	if (!isActive && el instanceof HTMLElement) {
+		el.blur();
+	}
+
 	if (el.hasAttribute('aria-selected')) {
 		el.setAttribute('aria-selected', String(isActive));
 	}

--- a/src/components/base/b-list/test/unit/main.ts
+++ b/src/components/base/b-list/test/unit/main.ts
@@ -300,4 +300,17 @@ test.describe('<b-list>', () => {
 			[[0, 1], [0], 'active']
 		]);
 	});
+
+	test('should remove focus from previous active element', async ({page}) => {
+		const
+			target = await renderList(page);
+
+		const links = await page.locator(`${createListSelector('link')}`);
+
+		await links.first().click();
+		await test.expect(links.first()).toBeFocused();
+
+		await target.evaluate((ctx) => ctx.setActive(1));
+		await test.expect(() => test.expect(links.first()).not.toBeFocused()).toPass();
+	});
 });


### PR DESCRIPTION
При программной смене активного айтема в b-list фокус остается на предыдущем айтеме, что неправильно.