### PR TITLE
fix(i-block/activation): reload for unloaded component or with `reloadOnActivation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 #### :house: Internal
 
-* Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`
-  `components/super/i-block/modules/activation`
+* Fixed an issue with reloading after a component is destroyed.
+Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`.
+`components/super/i-block/modules/activation`
 
 ## v4.0.0-beta.150 (2024-11-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ during a warn or error handler will trigger infinite recursion. `core/component/
 
 #### :house: Internal
 
-* Reloading now occurs only if the `reloadOnActivation` option is set to `true` `components/super/i-block/modules/activation`
+* Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`
+  `components/super/i-block/modules/activation`
 
 ## v4.0.0-beta.149 (2024-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ with certain warnings. Vue uses a `get` trap within the proxy to verify the pres
 of a property in the instance. Accessing undefined properties via the `getComponentInfo` method
 during a warn or error handler will trigger infinite recursion. `core/component/engines/vue3`
 
+#### :house: Internal
+
+* Reloading now occurs only if the `reloadOnActivation` option is set to `true` `components/super/i-block/modules/activation`
+
 ## v4.0.0-beta.149 (2024-10-31)
 
 #### :rocket: New Feature

--- a/src/components/super/i-block/modules/activation/CHANGELOG.md
+++ b/src/components/super/i-block/modules/activation/CHANGELOG.md
@@ -13,7 +13,8 @@ Changelog
 
 #### :house: Internal
 
-* Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`
+* Fixed an issue with reloading after a component is destroyed.
+Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`.
 
 ## v4.0.0-alpha.1 (2022-12-14)
 

--- a/src/components/super/i-block/modules/activation/CHANGELOG.md
+++ b/src/components/super/i-block/modules/activation/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 
 #### :house: Internal
 
-* Reloading now occurs only if the `reloadOnActivation` option is set to `true`
+* Reloading now occurs for unloaded components or when explicitly specified with `reloadOnActivation: true`
 
 ## v4.0.0-alpha.1 (2022-12-14)
 

--- a/src/components/super/i-block/modules/activation/CHANGELOG.md
+++ b/src/components/super/i-block/modules/activation/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.??? (2024-11-??)
+
+#### :house: Internal
+
+* Reloading now occurs only if the `reloadOnActivation` option is set to `true`
+
 ## v4.0.0-alpha.1 (2022-12-14)
 
 #### :memo: Documentation

--- a/src/components/super/i-block/modules/activation/index.ts
+++ b/src/components/super/i-block/modules/activation/index.ts
@@ -217,7 +217,7 @@ export function onDeactivated(component: iBlock): void {
 	async.forEach(($a) => {
 		Object.entries(Namespaces).forEach(([key, namespace]) => {
 			if (unsafe.reloadOnActivation && namespace === Namespaces.request) {
-				$a.muteRequest({group: 'i-data:initLoad'});
+				$a.muteAll({group: 'i-data:initLoad'});
 				return;
 			}
 

--- a/src/components/super/i-block/modules/activation/index.ts
+++ b/src/components/super/i-block/modules/activation/index.ts
@@ -219,7 +219,7 @@ export function onDeactivated(component: iBlock): void {
 	async.forEach(($a) => {
 		Object.entries(Namespaces).forEach(([key, namespace]) => {
 			if (unsafe.reloadOnActivation && namespace === Namespaces.request) {
-				$a.muteAll({group: 'i-data:initLoad'});
+				$a.muteRequest();
 				return;
 			}
 

--- a/src/components/super/i-block/modules/activation/index.ts
+++ b/src/components/super/i-block/modules/activation/index.ts
@@ -176,7 +176,9 @@ export function onActivated(component: iBlock, force: boolean = false): void {
 		unsafe.componentStatus = 'beforeReady';
 	}
 
-	if (unsafe.reloadOnActivation) {
+	const needInitLoadOrReload = unsafe.reloadOnActivation || unsafe.componentStatus === 'unloaded';
+
+	if (needInitLoadOrReload) {
 		const group = {group: 'requestSync:get'};
 		async.forEach(($a) => $a.clearAll(group).setImmediate(load, group));
 	}

--- a/src/components/super/i-block/modules/activation/index.ts
+++ b/src/components/super/i-block/modules/activation/index.ts
@@ -176,11 +176,7 @@ export function onActivated(component: iBlock, force: boolean = false): void {
 		unsafe.componentStatus = 'beforeReady';
 	}
 
-	const needInitLoadOrReload =
-		!unsafe.isReadyOnce &&
-		force || unsafe.reloadOnActivation;
-
-	if (needInitLoadOrReload) {
+	if (unsafe.reloadOnActivation) {
 		const group = {group: 'requestSync:get'};
 		async.forEach(($a) => $a.clearAll(group).setImmediate(load, group));
 	}
@@ -220,6 +216,11 @@ export function onDeactivated(component: iBlock): void {
 
 	async.forEach(($a) => {
 		Object.entries(Namespaces).forEach(([key, namespace]) => {
+			if (unsafe.reloadOnActivation && namespace === Namespaces.request) {
+				$a.muteRequest({group: 'i-data:initLoad'});
+				return;
+			}
+
 			if (Object.isNumber(namespace) && nonMuteAsyncNamespaces[namespace]) {
 				return;
 			}

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -40,7 +40,7 @@ test.describe('<i-block> modules - reload', () => {
 			});
 		});
 
-		test('should cancel the pending request when the component is deactivated', async () => {
+		test('should mute the pending request when the component is deactivated', async () => {
 			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
 
 			await target.evaluate((ctx) => ctx.deactivate());
@@ -93,7 +93,7 @@ test.describe('<i-block> modules - reload', () => {
 			await test.expect(mockReload.callsCount).resolves.toBe(0);
 		});
 
-		test('should continue the pending request when the component is deactivated', async () => {
+		test('should continue the pending request after activation', async () => {
 			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
 
 			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx, requestWait) => {

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -38,12 +38,12 @@ test.describe('<i-block> modules - reload', () => {
 		});
 
 		test('should mute the pending request when the component is deactivated', async () => {
-			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
+			const mockMuteRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
 
 			await target.evaluate((ctx) => ctx.deactivate());
 			await interceptor.respond();
 
-			await test.expect(mockClearRequest.calls).resolves.toEqual([[{group: 'i-data:initLoad'}]]);
+			await test.expect(mockMuteRequest.callsCount).resolves.toBe(1);
 		});
 
 		test('should reload the data on activation even if the data is already loaded', async () => {
@@ -92,7 +92,7 @@ test.describe('<i-block> modules - reload', () => {
 		});
 
 		test('should continue the pending request after activation', async () => {
-			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
+			const mockMuteRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
 
 			await target.evaluate((ctx) => ctx.deactivate());
 			await interceptor.respond();
@@ -105,7 +105,7 @@ test.describe('<i-block> modules - reload', () => {
 			const isReadyOnceAfterActivate = await target.evaluate((ctx) => ctx.isReadyOnce);
 			test.expect(isReadyOnceAfterActivate).toBe(true);
 
-			await test.expect(mockClearRequest.calls).resolves.toEqual([]);
+			await test.expect(mockMuteRequest.calls).resolves.toEqual([]);
 		});
 	});
 

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -37,7 +37,7 @@ test.describe('<i-block> modules - reload', () => {
 		});
 
 		test('should cancel the pending request when the component is deactivated', async () => {
-			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
+			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
 
 			await target.evaluate((ctx) => ctx.deactivate());
 

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -60,7 +60,8 @@ test.describe('<i-block> modules - reload', () => {
 				await ctx.waitComponentStatus('ready');
 			});
 
-			// We expect the reload method to be called twice because we have both safe and unsafe async modules
+			// We expect that the reload method will be called twice,
+			// since we are going through two instances of `async` and `$async` in the array
 			await test.expect(mockReload.callsCount).resolves.toBe(2);
 		});
 	});

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -9,10 +9,14 @@
 import type { JSHandle } from 'playwright';
 import test from 'tests/config/unit/test';
 
-import { BOM, Component, RequestInterceptor } from 'tests/helpers';
+import { Component, RequestInterceptor } from 'tests/helpers';
 import { createSpy } from 'tests/helpers/mock';
 
 import type bDummy from 'components/dummies/b-dummy/b-dummy';
+
+const
+	requestDelay = 50,
+	requestWait = requestDelay + 10;
 
 test.describe('<i-block> modules - reload', () => {
 	let
@@ -24,7 +28,7 @@ test.describe('<i-block> modules - reload', () => {
 		interceptor = new RequestInterceptor(page, /api/);
 
 		await interceptor
-			.response(200, {data: 'foo'}, {delay: 50})
+			.response(200, {data: 'foo'}, {delay: requestDelay})
 			.start();
 	});
 
@@ -44,20 +48,20 @@ test.describe('<i-block> modules - reload', () => {
 			await test.expect(mockClearRequest.calls).resolves.toEqual([[{group: 'i-data:initLoad'}]]);
 		});
 
-		test('should reload the data on activation even if the data is already loaded', async ({page}) => {
+		test('should reload the data on activation even if the data is already loaded', async () => {
 			const mockReload = await createSpy(target, (ctx) => jestMock.spy(ctx, 'reload'));
 
-			await target.evaluate(async (ctx) => {
-				await ctx.unsafe.async.sleep(50);
+			await target.evaluate(async (ctx, requestWait) => {
+				await ctx.unsafe.async.sleep(requestWait);
 
 				ctx.deactivate();
 
 				await ctx.waitComponentStatus('inactive');
 
 				ctx.activate();
-			});
 
-			await BOM.waitForIdleCallback(page);
+				await ctx.waitComponentStatus('ready');
+			}, requestWait);
 
 			// We expect the reload method to be called twice because we have both safe and unsafe async modules
 			await test.expect(mockReload.callsCount).resolves.toBe(2);
@@ -71,20 +75,20 @@ test.describe('<i-block> modules - reload', () => {
 			});
 		});
 
-		test('should not reload the data on activation if the data is already loaded', async ({page}) => {
+		test('should not reload the data on activation if the data is already loaded', async () => {
 			const mockReload = await createSpy(target, (ctx) => jestMock.spy(ctx, 'reload'));
 
 			await target.evaluate(async (ctx) => {
-				await ctx.unsafe.async.sleep(50);
+				await ctx.waitComponentStatus('ready');
 
 				ctx.deactivate();
 
 				await ctx.waitComponentStatus('inactive');
 
 				ctx.activate();
-			});
 
-			await BOM.waitForIdleCallback(page);
+				await ctx.waitComponentStatus('ready');
+			});
 
 			await test.expect(mockReload.callsCount).resolves.toBe(0);
 		});
@@ -92,13 +96,13 @@ test.describe('<i-block> modules - reload', () => {
 		test('should continue the pending request when the component is deactivated', async () => {
 			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
 
-			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx) => {
+			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx, requestWait) => {
 				ctx.deactivate();
 
-				await ctx.unsafe.async.sleep(50);
+				await ctx.unsafe.async.sleep(requestWait);
 
 				return ctx.isReadyOnce;
-			});
+			}, requestWait);
 
 			test.expect(isReadyOnceAfterDeactivate).toBe(false);
 
@@ -108,6 +112,72 @@ test.describe('<i-block> modules - reload', () => {
 
 			test.expect(isReadyOnceAfterActivate).toBe(true);
 			await test.expect(mockClearRequest.calls).resolves.toEqual([]);
+		});
+	});
+
+	test.describe('unloaded component', () => {
+		test.beforeEach(async ({page}) => {
+			target = await Component.createComponent(page, 'b-dummy', {
+				dataProvider: 'Provider',
+				activated: false
+			});
+		});
+
+		test('should load the data on activation', async () => {
+			const mockInitLoad = await createSpy(target, (ctx) => jestMock.spy(ctx, 'initLoad'));
+
+			await target.evaluate(async (ctx) => {
+				ctx.activate();
+
+				await ctx.waitComponentStatus('ready');
+			});
+
+			await test.expect(mockInitLoad.callsCount).resolves.toBe(1);
+		});
+
+		test('should not reload the data after second activation', async () => {
+			const mockReload = await createSpy(target, (ctx) => jestMock.spy(ctx, 'reload'));
+
+			await target.evaluate(async (ctx) => {
+				ctx.activate();
+
+				await ctx.waitComponentStatus('ready');
+
+				ctx.deactivate();
+
+				await ctx.waitComponentStatus('inactive');
+
+				ctx.activate();
+
+				await ctx.waitComponentStatus('ready');
+			});
+
+			await test.expect(mockReload.callsCount).resolves.toBe(0);
+		});
+
+		test('should continue the pending request after second activation', async () => {
+			const mockInitLoad = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe, 'initLoad'));
+
+			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx, requestWait) => {
+				ctx.activate();
+
+				await ctx.unsafe.async.nextTick();
+
+				ctx.deactivate();
+
+				await ctx.unsafe.async.sleep(requestWait);
+
+				return ctx.isReadyOnce;
+			}, requestWait);
+
+			test.expect(isReadyOnceAfterDeactivate).toBe(false);
+
+			await target.evaluate((ctx) => ctx.activate());
+
+			const isReadyOnceAfterActivate = await target.evaluate((ctx) => ctx.isReadyOnce);
+
+			test.expect(isReadyOnceAfterActivate).toBe(true);
+			await test.expect(mockInitLoad.callsCount).resolves.toBe(1);
 		});
 	});
 });

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -6,7 +6,7 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
-import { JSHandle } from 'playwright';
+import type { JSHandle } from 'playwright';
 import test from 'tests/config/unit/test';
 
 import { BOM, Component, RequestInterceptor } from 'tests/helpers';

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -1,0 +1,113 @@
+/*!
+ * V4Fire Client Core
+ * https://github.com/V4Fire/Client
+ *
+ * Released under the MIT license
+ * https://github.com/V4Fire/Client/blob/master/LICENSE
+ */
+
+import { JSHandle } from 'playwright';
+import test from 'tests/config/unit/test';
+
+import { BOM, Component, RequestInterceptor } from 'tests/helpers';
+import { createSpy } from 'tests/helpers/mock';
+
+import type bDummy from 'components/dummies/b-dummy/b-dummy';
+
+test.describe('<i-block> modules - reload', () => {
+	let
+		target: JSHandle<bDummy>,
+		interceptor: RequestInterceptor;
+
+	test.beforeEach(async ({demoPage, page}) => {
+		await demoPage.goto();
+		interceptor = new RequestInterceptor(page, /api/);
+
+		await interceptor
+			.response(200, {data: 'foo'}, {delay: 50})
+			.start();
+	});
+
+	test.describe('reloadOnActivation = true', () => {
+		test.beforeEach(async ({page}) => {
+			target = await Component.createComponent(page, 'b-dummy', {
+				dataProvider: 'Provider',
+				reloadOnActivation: true
+			});
+		});
+
+		test('should cancel the pending request when the component is deactivated', async () => {
+			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
+
+			await target.evaluate((ctx) => ctx.deactivate());
+
+			await test.expect(mockClearRequest.calls).resolves.toEqual([[{group: 'i-data:initLoad'}]]);
+		});
+
+		test('should reload the data on activation even if the data is already loaded', async ({page}) => {
+			const mockReload = await createSpy(target, (ctx) => jestMock.spy(ctx, 'reload'));
+
+			await target.evaluate(async (ctx) => {
+				await ctx.unsafe.async.sleep(50);
+
+				ctx.deactivate();
+
+				await ctx.waitComponentStatus('inactive');
+
+				ctx.activate();
+			});
+
+			await BOM.waitForIdleCallback(page);
+
+			// We expect the reload method to be called twice because we have both safe and unsafe async modules
+			await test.expect(mockReload.callsCount).resolves.toBe(2);
+		});
+	});
+
+	test.describe('reloadOnActivation = false', () => {
+		test.beforeEach(async ({page}) => {
+			target = await Component.createComponent(page, 'b-dummy', {
+				dataProvider: 'Provider'
+			});
+		});
+
+		test('should not reload the data on activation if the data is already loaded', async ({page}) => {
+			const mockReload = await createSpy(target, (ctx) => jestMock.spy(ctx, 'reload'));
+
+			await target.evaluate(async (ctx) => {
+				await ctx.unsafe.async.sleep(50);
+
+				ctx.deactivate();
+
+				await ctx.waitComponentStatus('inactive');
+
+				ctx.activate();
+			});
+
+			await BOM.waitForIdleCallback(page);
+
+			await test.expect(mockReload.callsCount).resolves.toBe(0);
+		});
+
+		test('should continue the pending request when the component is deactivated', async ({page}) => {
+			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
+
+			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx) => {
+				ctx.deactivate();
+
+				await ctx.unsafe.async.sleep(50);
+
+				return ctx.isReadyOnce;
+			});
+
+			test.expect(isReadyOnceAfterDeactivate).toBe(false);
+
+			await target.evaluate((ctx) => ctx.activate());
+
+			const isReadyOnceAfterActivate = await target.evaluate((ctx) => ctx.isReadyOnce);
+
+			test.expect(isReadyOnceAfterActivate).toBe(true);
+			await test.expect(mockClearRequest.calls).resolves.toEqual([]);
+		});
+	});
+});

--- a/src/components/super/i-block/modules/activation/test/unit/reload.ts
+++ b/src/components/super/i-block/modules/activation/test/unit/reload.ts
@@ -89,8 +89,8 @@ test.describe('<i-block> modules - reload', () => {
 			await test.expect(mockReload.callsCount).resolves.toBe(0);
 		});
 
-		test('should continue the pending request when the component is deactivated', async ({page}) => {
-			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteRequest'));
+		test('should continue the pending request when the component is deactivated', async () => {
+			const mockClearRequest = await createSpy(target, (ctx) => jestMock.spy(ctx.unsafe.async, 'muteAll'));
 
 			const isReadyOnceAfterDeactivate = await target.evaluate(async (ctx) => {
 				ctx.deactivate();

--- a/src/components/super/i-data/i-data.ts
+++ b/src/components/super/i-data/i-data.ts
@@ -77,6 +77,7 @@ export default abstract class iData extends iDataHandlers {
 
 		const label = <AsyncOptions>{
 			label: $$.initLoad,
+			group: 'i-data:initLoad',
 			join: 'replace'
 		};
 

--- a/src/components/super/i-data/i-data.ts
+++ b/src/components/super/i-data/i-data.ts
@@ -77,7 +77,6 @@ export default abstract class iData extends iDataHandlers {
 
 		const label = <AsyncOptions>{
 			label: $$.initLoad,
-			group: 'i-data:initLoad',
 			join: 'replace'
 		};
 


### PR DESCRIPTION
## Описание проблемы

Мы перед созданием компонента вызываем `initLoad`, до его завершения мы покидаем страницу, если ещё точнее, нас волнует поле `isReadyOnce`, оно остается `false`. Затем возвращаемся на эту страницу, мы попадаем в `onActivated` и регистрируем `setImmediate` https://github.com/V4Fire/Client/blob/503435cdc7e12edf2236a63dc01253c4115f909d/src/components/super/i-block/modules/activation/index.ts#L185
после этого продолжается запрос `initLoad` и выставляется `isReadyOnce = true`. После чего вызывается колбэк из `setImmediate`, который в зависимости от `isReadyOnce` вызывает либо `reload`, либо `initLoad`
https://github.com/V4Fire/Client/blob/503435cdc7e12edf2236a63dc01253c4115f909d/src/components/super/i-block/modules/activation/index.ts#L199-L201

В `reload` у нас в `i-data` есть `(await this.remoteState.net.isOnline()).status`, и после вызов `super.reload()`.
https://github.com/V4Fire/Client/blob/503435cdc7e12edf2236a63dc01253c4115f909d/src/components/super/i-data/i-data.ts#L265-L269

И до вызова `super.reload`, у нас происходит ререндер, так как данных нет и мы скрываем `b-virtual-scroll` через `v-if`, происходит его дестрой и затем мы доходим до `super.reload` который как раз падает с ошибкой, так как компонент уже уничтожен

### Стектрейс ошибки

```
TypeError: Cannot read properties of undefined (reading 'lfc')
  at initLoad (https://cb.edadeal.ru/v2:90:615779)
  at Proxy.s (https://cb.edadeal.ru/v2:90:1316714)
  at Object.reload (https://cb.edadeal.ru/v2:90:759712)
  at Object.reload (https://cb.edadeal.ru/v2:90:1230091)
```


