### PR TITLE
fix(page-meta-data): handle quotation marks in query selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 with certain warnings. Vue uses a `get` trap within the proxy to verify the presence
 of a property in the instance. Accessing undefined properties via the `getComponentInfo` method
 during a warn or error handler will trigger infinite recursion. `core/component/engines/vue3`
+* The `create` method now handles quotation marks in meta tag values when building query selectors `core/page-meta-data/elements/abstract/engines/dom`
 
 ## v4.0.0-beta.149 (2024-10-31)
 

--- a/src/core/page-meta-data/CHANGELOG.md
+++ b/src/core/page-meta-data/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
-## v4.0.0-beta.150 (2024-11-05)
+## v4.0.0-beta.?? (2024-11-??)
 
 #### :bug: Bug Fix
 

--- a/src/core/page-meta-data/CHANGELOG.md
+++ b/src/core/page-meta-data/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.150 (2024-11-05)
+
+#### :bug: Bug Fix
+
+* The `create` method now handles quotation marks in meta tag values when building query selectors
+
 ## v4.0.0-beta.110 (2024-07-17)
 
 #### :bug: Bug Fix

--- a/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
+++ b/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
@@ -12,7 +12,9 @@ export class DOMEngine<T extends HTMLElement> implements Engine {
 	/** {@link Engine.create} */
 	create(tag: string, attrs: Dictionary<string>): T {
 		const selector = Object.entries(attrs).reduce((acc, [key, val]) => {
-			acc += `[${key}="${val}"]`;
+			const normalizedVal = val == null ? val : val.replace(/"/g, '\\"');
+
+			acc += `[${key}="${normalizedVal}"]`;
 			return acc;
 		}, `${tag}`);
 

--- a/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
+++ b/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
@@ -12,7 +12,7 @@ export class DOMEngine<T extends HTMLElement> implements Engine {
 	/** {@link Engine.create} */
 	create(tag: string, attrs: Dictionary<string>): T {
 		const selector = Object.entries(attrs).reduce((acc, [key, val]) => {
-			const normalizedVal = val == null ? val : val.replaceAll('"', '\\"');
+			const normalizedVal = val == null ? '' : val.replaceAll('"', '\\"');
 
 			acc += `[${key}="${normalizedVal}"]`;
 			return acc;

--- a/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
+++ b/src/core/page-meta-data/elements/abstract/engines/dom/index.ts
@@ -12,7 +12,7 @@ export class DOMEngine<T extends HTMLElement> implements Engine {
 	/** {@link Engine.create} */
 	create(tag: string, attrs: Dictionary<string>): T {
 		const selector = Object.entries(attrs).reduce((acc, [key, val]) => {
-			const normalizedVal = val == null ? val : val.replace(/"/g, '\\"');
+			const normalizedVal = val == null ? val : val.replaceAll('"', '\\"');
 
 			acc += `[${key}="${normalizedVal}"]`;
 			return acc;


### PR DESCRIPTION
Бывает, что в title/description прилетает строка с кавычками, например `Игрушка "Воздушный змей", Sport&Fun, в ассортименте – купить по выгодной цене в Москва – Едадил`. Вставляется в DOM нормально, но при создании селектора `meta[title="Игрушка "Воздушный змей", Sport&Fun, в ассортименте – купить по выгодной цене в Москва – Едадил"]` будет ошибка.