### PR TITLE
chore: revert exclude ssr shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ with certain warnings. Vue uses a `get` trap within the proxy to verify the pres
 of a property in the instance. Accessing undefined properties via the `getComponentInfo` method
 during a warn or error handler will trigger infinite recursion. `core/component/engines/vue3`
 
+#### :house: Internal
+
+* Revert: exclude SSR shims for non-SSR environments `core/shims`
+
 ## v4.0.0-beta.149 (2024-10-31)
 
 #### :rocket: New Feature

--- a/src/core/shims/index.ts
+++ b/src/core/shims/index.ts
@@ -7,6 +7,4 @@
  */
 
 import 'core/shims/set-immediate';
-//#if runtime has ssr
 import 'core/shims/ssr';
-//#endif


### PR DESCRIPTION
It seems that SSR version of requestIdleCallback polyfill is better