### PR TITLE
Fix ref tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-11-??)
+
+#### :bug: Bug Fix
+
+* Re-fixed loss of refs in slots inside async render (see v4.0.0-beta.52)
+  by converting `v-ref` to a prop for regular components `build/snakeskin/filters`
+
+#### :house: Internal
+
+* Removed context binding in wrapRenderList `core/component/render`
+
+
 ## v4.0.0-beta.152 (2024-11-11)
 
 #### :rocket: New Feature

--- a/build/snakeskin/CHANGELOG.md
+++ b/build/snakeskin/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-11-??)
+
+#### :bug: Bug Fix
+
+* Re-fixed loss of refs in slots inside async render (see v4.0.0-beta.52)
+  by converting `v-ref` to a prop for regular components `build/snakeskin/filters`
+
 ## v4.0.0-beta.145 (2024-10-14)
 
 #### :bug: Bug Fix

--- a/build/snakeskin/filters/tag.js
+++ b/build/snakeskin/filters/tag.js
@@ -80,7 +80,7 @@ module.exports = [
 
 		// Adding the v-ref directive to a non-functional component can lead to excessive re-renders
 		// with any change in the parent state, so we add it as a prop
-		if (!isSimpleTag && !isFunctional && !vFuncDir) {
+		if (!isSimpleTag && !isFunctional && vFuncDir !== 'true') {
 			vRef = `:${vRef}`;
 		}
 

--- a/components-lock.json
+++ b/components-lock.json
@@ -1,5 +1,5 @@
 {
-  "hash": "7b16e904c8d6785034161f61a4a4b42111ccf767585d6f643478eec974899aa8",
+  "hash": "8f18802f0b580482f8a74dc03c996770a4b40f666d675930c34391d617e48966",
   "data": {
     "%data": "%data:Map",
     "%data:Map": [
@@ -2866,6 +2866,7 @@
             "parent": "i-static-page",
             "dependencies": [
               "b-dummy",
+              "b-directives-ref-dummy",
               "b-router",
               "b-dynamic-page",
               "b-remote-provider",
@@ -2915,6 +2916,7 @@
           "parent": "i-static-page",
           "dependencies": [
             "b-dummy",
+            "b-directives-ref-dummy",
             "b-router",
             "b-dynamic-page",
             "b-remote-provider",

--- a/src/components/pages/p-v4-components-demo/index.js
+++ b/src/components/pages/p-v4-components-demo/index.js
@@ -10,6 +10,7 @@ package('p-v4-components-demo')
 	.extends('i-static-page')
 	.dependencies(
 		'b-dummy',
+		'b-directives-ref-dummy',
 
 		'b-router',
 		'b-dynamic-page',

--- a/src/components/pages/p-v4-components-demo/p-v4-components-demo.ss
+++ b/src/components/pages/p-v4-components-demo/p-v4-components-demo.ss
@@ -15,8 +15,8 @@
 		< template v-if = stage === 'teleports'
 			< b-bottom-slide
 
-		< template v-if = stage.startsWith('refs:')
+		< template v-if = stage?.startsWith('refs:')
 			< b-directives-ref-dummy :stage = stage.split(':')[1]
 
-		< template v-if = stage.startsWith('refs-async:')
+		< template v-if = stage?.startsWith('refs-async:')
 			< b-directives-ref-dummy :useAsyncRender = true | :stage = stage.split(':')[1]

--- a/src/components/pages/p-v4-components-demo/p-v4-components-demo.ss
+++ b/src/components/pages/p-v4-components-demo/p-v4-components-demo.ss
@@ -14,3 +14,9 @@
 	- block body
 		< template v-if = stage === 'teleports'
 			< b-bottom-slide
+
+		< template v-if = stage.startsWith('refs:')
+			< b-directives-ref-dummy :stage = stage.split(':')[1]
+
+		< template v-if = stage.startsWith('refs-async:')
+			< b-directives-ref-dummy :useAsyncRender = true | :stage = stage.split(':')[1]

--- a/src/core/component/directives/ref/index.ts
+++ b/src/core/component/directives/ref/index.ts
@@ -24,10 +24,6 @@ import type { DirectiveOptions } from 'core/component/directives/ref/interface';
 export * from 'core/component/directives/ref/const';
 export * from 'core/component/directives/ref/interface';
 
-//#if runtime has dummyComponents
-import('core/component/directives/ref/test/b-directives-ref-dummy');
-//#endif
-
 ComponentEngine.directive('ref', {
 	mounted: updateRef,
 	updated: updateRef

--- a/src/core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy.ss
+++ b/src/core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy.ss
@@ -33,6 +33,12 @@
 					< b-dummy ref = slotComponent | id = slot | v-func = true
 						< b-dummy ref = nestedSlotComponent | id = nested
 
+			< template v-if = stage === 'slot component has directive'
+				< b-dummy ref = component | id = main
+					/// Adding a directive so that a vnode becomes wrapped by the "withDirectives" helper
+					< b-dummy ref = slotComponent | id = slot | v-func = false
+						< b-dummy ref = nestedSlotComponent | id = nested
+
 			< template v-else-if = stage === 'main component is regular and slot components are functional'
 				< b-dummy ref = component | id = main
 					< b-dummy ref = slotComponent | id = slot | v-func = true

--- a/src/core/component/directives/ref/test/unit/main.ts
+++ b/src/core/component/directives/ref/test/unit/main.ts
@@ -12,7 +12,7 @@ import type { JSHandle, Page } from 'playwright';
 import test from 'tests/config/unit/test';
 import { BOM, Component } from 'tests/helpers';
 
-import bDirectivesRefDummy from 'core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy';
+import type bDirectivesRefDummy from 'core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy';
 
 type RefKey = keyof Pick<bDirectivesRefDummy['$refs'], 'component' | 'slotComponent' | 'nestedSlotComponent'>;
 

--- a/src/core/component/directives/ref/test/unit/main.ts
+++ b/src/core/component/directives/ref/test/unit/main.ts
@@ -22,6 +22,7 @@ test.describe('core/component/directives/ref', () => {
 		'all components are functional',
 		'main component is functional and slot components are regular',
 		'only one slot component is functional',
+		'slot component has directive',
 		'main component is regular and slot components are functional'
 	];
 

--- a/src/core/component/directives/ref/test/unit/main.ts
+++ b/src/core/component/directives/ref/test/unit/main.ts
@@ -6,29 +6,55 @@
  * https://github.com/V4Fire/Client/blob/master/LICENSE
  */
 
+import { toQueryString } from 'core/url';
 import type { JSHandle, Page } from 'playwright';
 
 import test from 'tests/config/unit/test';
 import { BOM, Component } from 'tests/helpers';
 
-import type bDirectivesRefDummy from 'core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy';
+import bDirectivesRefDummy from 'core/component/directives/ref/test/b-directives-ref-dummy/b-directives-ref-dummy';
 
 type RefKey = keyof Pick<bDirectivesRefDummy['$refs'], 'component' | 'slotComponent' | 'nestedSlotComponent'>;
 
 test.describe('core/component/directives/ref', () => {
-	test.beforeEach(async ({demoPage, page}) => {
-		await demoPage.goto();
-		await Component.waitForComponentTemplate(page, 'b-directives-ref-dummy');
+	const stages = [
+		'all components are regular',
+		'all components are functional',
+		'main component is functional and slot components are regular',
+		'only one slot component is functional',
+		'main component is regular and slot components are functional'
+	];
+
+	test.describe('the ref should be correctly resolved on the root page', () => {
+		test.describe('during regular render', () => {
+			stages.forEach((stage) => {
+				test(`when ${stage}`, async ({demoPage, page}) => {
+					await demoPage.goto(toQueryString({stage: `refs:${stage}`}));
+					const target = await Component.getComponentByQuery<bDirectivesRefDummy>(page, '.b-directives-ref-dummy');
+
+					await assertRefsAreCorrect(target!);
+				});
+			});
+		});
+
+		test.describe('during async render', () => {
+			stages.forEach((stage) => {
+				test(`when ${stage}`, async ({demoPage, page}) => {
+					await demoPage.goto(toQueryString({stage: `refs-async:${stage}`}));
+					const target = await Component.getComponentByQuery<bDirectivesRefDummy>(page, '.b-directives-ref-dummy');
+
+					await BOM.waitForIdleCallback(page);
+
+					await assertRefsAreCorrect(target!);
+				});
+			});
+		});
 	});
 
 	test.describe('the ref should be correctly resolved', () => {
-		const stages = [
-			'all components are regular',
-			'all components are functional',
-			'main component is functional and slot components are regular',
-			'only one slot component is functional',
-			'main component is regular and slot components are functional'
-		];
+		test.beforeEach(async ({demoPage}) => {
+			await demoPage.goto();
+		});
 
 		test.describe('during regular render', () => {
 			stages.forEach((stage) => {

--- a/src/core/component/engines/vue3/render.ts
+++ b/src/core/component/engines/vue3/render.ts
@@ -143,23 +143,7 @@ export const
 
 export const withModifiers = wrapWithModifiers(superWithModifiers);
 
-export const renderList = wrapRenderList(
-	superRenderList,
-	(...args: Parameters<typeof superWithCtx>) => {
-		// Vue has two contexts for instances: `currentInstance` and `currentRenderingInstance`.
-		// The context for the renderList should be a `currentRenderingInstance`
-		// because `renderList` is called during component rendering.
-		const fn = superWithCtx(...args);
-
-		// Enable block tracking
-		// @see https://github.com/vuejs/core/blob/45984d559fe0c036657d5f2626087ea8eec205a8/packages/runtime-core/src/componentRenderContext.ts#L88
-		if ('_d' in fn) {
-			(<Function & {_d: boolean}>fn)._d = false;
-		}
-
-		return fn;
-	}
-);
+export const renderList = wrapRenderList(superRenderList);
 
 /**
  * Renders the specified VNode and returns the result

--- a/src/core/component/render/CHANGELOG.md
+++ b/src/core/component/render/CHANGELOG.md
@@ -9,6 +9,12 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-11-??)
+
+#### :house: Internal
+
+* Removed context binding in wrapRenderList
+
 ## v4.0.0-beta.151 (2024-11-06)
 
 #### :bug: Bug Fix

--- a/src/core/component/render/wrappers.ts
+++ b/src/core/component/render/wrappers.ts
@@ -303,19 +303,13 @@ export function wrapMergeProps<T extends typeof mergeProps>(original: T): T {
  * @param original
  * @param withCtx
  */
-export function wrapRenderList<T extends typeof renderList, C extends typeof withCtx>(original: T, withCtx: C): T {
+export function wrapRenderList<T extends typeof renderList>(original: T): T {
 	return Object.cast(function renderList(
 		this: ComponentInterface,
 		src: Nullable<Iterable<unknown> | Dictionary | number>,
 		cb: AnyFunction
 	) {
 		const wrappedCb: AnyFunction = Object.cast(cb);
-
-		// const
-		// 	ctx = this.$renderEngine.r.getCurrentInstance(),
-
-		// 	// Preserve rendering context for the async render
-		// 	wrappedCb: AnyFunction = Object.cast(withCtx(cb, ctx));
 
 		const
 			vnodes = original(src, wrappedCb),
@@ -397,15 +391,12 @@ export function wrapWithDirectives<T extends typeof withDirectives>(_: T): T {
 		const that = this;
 		patchVNode(vnode);
 
-		console.log(vnode.dirs);
 		const bindings = vnode.dirs ?? [];
 		vnode.dirs = bindings;
 
 		const instance = this?.unsafe.meta.params.functional === true ?
 			Object.cast(this.$normalParent) :
 			this;
-
-		console.log(vnode, instance.componentName, instance.componentId);
 
 		dirs.forEach((decl) => {
 			const [dir, value, arg, modifiers] = decl;

--- a/src/core/component/render/wrappers.ts
+++ b/src/core/component/render/wrappers.ts
@@ -309,11 +309,13 @@ export function wrapRenderList<T extends typeof renderList, C extends typeof wit
 		src: Nullable<Iterable<unknown> | Dictionary | number>,
 		cb: AnyFunction
 	) {
-		const
-			ctx = this.$renderEngine.r.getCurrentInstance(),
+		const wrappedCb: AnyFunction = Object.cast(cb);
 
-			// Preserve rendering context for the async render
-			wrappedCb: AnyFunction = Object.cast(withCtx(cb, ctx));
+		// const
+		// 	ctx = this.$renderEngine.r.getCurrentInstance(),
+
+		// 	// Preserve rendering context for the async render
+		// 	wrappedCb: AnyFunction = Object.cast(withCtx(cb, ctx));
 
 		const
 			vnodes = original(src, wrappedCb),
@@ -395,12 +397,15 @@ export function wrapWithDirectives<T extends typeof withDirectives>(_: T): T {
 		const that = this;
 		patchVNode(vnode);
 
+		console.log(vnode.dirs);
 		const bindings = vnode.dirs ?? [];
 		vnode.dirs = bindings;
 
 		const instance = this?.unsafe.meta.params.functional === true ?
 			Object.cast(this.$normalParent) :
 			this;
+
+		console.log(vnode, instance.componentName, instance.componentId);
 
 		dirs.forEach((decl) => {
 			const [dir, value, arg, modifiers] = decl;


### PR DESCRIPTION
Дебажил на следующем примере:

```js
< . v-async-target
	+= self.render({ wait: 'async.sleep.bind(async, 0)' })
		< b-dummy ref = rfc
			< b-dummy ref = nested | v-func = false
```

Проблема в том, что при наличии v-func v-ref не преобразовывается в проп, а остается директивой.

Когда v-ref является пропом и асинхронно рендерится слот, то у нас явно в качестве this пробрасывается контекст в котором этот слот объявлен:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/cddac101-a83d-4700-8970-7e1fa4df6cb1">

Далее в resolveAttrs этот this пробрасывается как instance в директиву, тем самым верно определяется цель для записи рефов:
https://github.com/V4Fire/Client/blob/a779b615409516ba46b69a891bf7e7c495b352a1/src/core/component/render/helpers/attrs.ts#L107-L124

**UPD:** оказывается instance в обоих случаях верный, но в случае вызова resolveAttrs и invokeDirectiveHook vnode имеет разные параметры. Когда v-ref вызывается через invokeDirectiveHook на вход поступает другая vnode (у неё отличается patchFlag, children, component и ref равен null из-за чего собственно и не получается задать реф). Причём свойство "el" у них ссылается на один и тот же DOM узел.

**В первом случае у нас vnode компонента, а во втором vnode узла, который и будет маунтится. При это директивы наследуются от внешнего узла компонента:**

<img width="755" alt="image" src="https://github.com/user-attachments/assets/61b39846-ca5a-4148-8f61-ac23c6fc8127">

Здесь представлена vnode, которая поступает в директиву в случае resolveAttrs:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/27fdaf3a-75e3-433f-965a-55d768ba9dd4">

А тут vnode, которая прокидывается в invokeDirectiveHook при срабатывании коллбэка в queuePostRenderEffect:
<img width="860" alt="image" src="https://github.com/user-attachments/assets/ff28e1d6-1e6b-40b5-aca0-9d2c0cb6f0c0">

**Итого:** в Vue на внешнем узле компонента вызывается только директивы на beforeUnmount, если в пропсах задано свойство `onVnodeBeforeMount`. Обычные директивы при этом копируются на корневой узел компонента и вызываются после завершения рендера с помощью queuePostRenderEffect. В нашем случае у корневого узла компонента свойство ref = null, так как это асинхронный рендер. Конечно было бы правильно сохранять контекст рендера в рамках которого мы начали асинхронный рендер, но это ломается при обновлении на новый Vue.
