### PR TITLE
fix(core/component/watch): binding non-promise handler for custom watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,6 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 * Fix binding a non-promise handler for the custom watcher.
 After rewriting the loop from `.forEach` to native `for`, `return` statement was not changed to `continue`.
 `core/component/watch`
-
-## v4.0.0-beta.?? (2024-12-??)
-
-#### :bug: Bug Fix
-
 * Add "flush: 'sync'" to the page watcher. This restores the original semantics of the "immediate: true" option `bDynamicPage`
 
 ## v4.0.0-beta.164 (2024-12-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Changelog
 
 _Note: Gaps between patch versions are faulty, broken or test releases._
 
+## v4.0.0-beta.?? (2024-12-??)
+
+#### :bug: Bug Fix
+
+* Fix binding a non-promise handler for the custom watcher.
+After rewriting the loop from `.forEach` to native `for`, `return` statement was not changed to `continue`.
+`core/component/watch`
+
 ## v4.0.0-beta.163 (2024-12-05)
 
 #### :boom: Breaking Change

--- a/src/core/component/watch/CHANGELOG.md
+++ b/src/core/component/watch/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog
 > - :house:      [Internal]
 > - :nail_care:  [Polish]
 
+## v4.0.0-beta.?? (2024-12-??)
+
+#### :bug: Bug Fix
+
+* Fix binding a non-promise handler for the custom watcher.
+After rewriting the loop from `.forEach` to native `for`, `return` statement was not changed to `continue`.
+
 ## v4.0.0-beta.161 (2024-12-03)
 
 #### :bug: Bug Fix

--- a/src/core/component/watch/bind.ts
+++ b/src/core/component/watch/bind.ts
@@ -324,7 +324,7 @@ export function bindRemoteWatchers(component: ComponentInterface, params?: BindR
 							}
 						}
 
-						return;
+						continue;
 					}
 
 					/* eslint-disable prefer-const */


### PR DESCRIPTION
After rewriting the loop from `.forEach` to native `for`, `return` statement was not changed to `continue`.